### PR TITLE
Index page for submissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'jbuilder', '~> 2.5'
 #
 gem 'devise'
 gem 'react-rails'
+gem 'active_model_serializers'
 
 # Configuration
 gem 'dotenv-rails', '~> 2.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 #
 gem 'devise'
+gem 'react-rails'
 
 # Configuration
 gem 'dotenv-rails', '~> 2.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,10 @@ GEM
     airbrussh (1.1.1)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
+    babel-source (5.8.35)
+    babel-transpiler (0.7.0)
+      babel-source (>= 4.0, < 6)
+      execjs (~> 2.0)
     bcrypt (3.1.11)
     builder (3.2.2)
     byebug (9.0.6)
@@ -70,6 +74,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    connection_pool (2.2.0)
     debug_inspector (0.0.2)
     devise (4.2.0)
       bcrypt (~> 3.0)
@@ -154,6 +159,13 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    react-rails (1.9.0)
+      babel-transpiler (>= 0.7.0)
+      coffee-script-source (~> 1.8)
+      connection_pool
+      execjs
+      railties (>= 3.2)
+      tilt
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
@@ -238,6 +250,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   pg
   rails (~> 5.0.0, >= 5.0.0.1)
+  react-rails
   rspec-rails
   sass-rails (~> 5.0)
   secondbase

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.10.2)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      jsonapi (~> 0.1.1.beta2)
+      railties (>= 4.1, < 6)
     activejob (5.0.0.1)
       activesupport (= 5.0.0.1)
       globalid (>= 0.3.6)
@@ -107,6 +112,11 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jsonapi (0.1.1.beta6)
+      jsonapi-parser (= 0.1.1.beta3)
+      jsonapi-renderer (= 0.1.1.beta1)
+    jsonapi-parser (0.1.1.beta3)
+    jsonapi-renderer (0.1.1.beta1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -234,6 +244,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   byebug
   capistrano (~> 3.4)
   capistrano-bundler (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (0.1.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -261,6 +265,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   pg
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   react-rails
   rspec-rails
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require react
+//= require react_ujs
+//= require components
 //= require_tree .

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,0 +1,1 @@
+//= require_tree ./components

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -3,6 +3,6 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
   render: ->
     p(
       {}
-      @props.annualReportUpload.id
+      @props.annualReportUpload.file_name
     )
 

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -1,0 +1,8 @@
+{p} = React.DOM
+window.AnnualReportUpload = class AnnualReportUpload extends React.Component
+  render: ->
+    p(
+      {}
+      @props.annualReportUpload.id
+    )
+

--- a/app/assets/javascripts/components/annual_report_uploads.js.coffee
+++ b/app/assets/javascripts/components/annual_report_uploads.js.coffee
@@ -1,0 +1,20 @@
+{div, h1, h2, p, i} = React.DOM
+window.AnnualReportUploads = class AnnualReportUploads extends React.Component
+  constructor: (props, context) ->
+    super(props, context)
+    @state = { annualReportUploads: props.data }
+
+  render: ->
+    uploads = @generateUploads()
+    div
+      className: 'annual-report-uploads'
+      @generateUploads()
+
+
+  generateUploads: ->
+    for annualReportUpload in @state.annualReportUploads
+      div(
+        {key: annualReportUpload.id}
+        React.createElement(AnnualReportUpload, {key: annualReportUpload.id, annualReportUpload: annualReportUpload})
+      )
+

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,4 +1,5 @@
 class AnnualReportUploadsController < ApplicationController
+  before_action :authenticate_user!
   respond_to :json
 
   def index
@@ -12,5 +13,11 @@ class AnnualReportUploadsController < ApplicationController
     @in_progress_uploads = @annual_report_uploads.in_progress.map do |aru|
         AnnualReportUploadSerializer.new(aru)
     end
+  end
+
+  private
+
+  def authenticate_user!
+    render "unauthorised" unless (current_epix_user || current_sapi_user).present?
   end
 end

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -2,6 +2,9 @@ class AnnualReportUploadsController < ApplicationController
   respond_to :json
 
   def index
-    @annual_report_uploads = Sapi::Trade::AnnualReportUpload.all
+    @annual_report_uploads =
+      Sapi::Trade::AnnualReportUpload.all.map do |aru|
+        AnnualReportUploadSerializer.new(aru)
+      end
   end
 end

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -2,8 +2,9 @@ class AnnualReportUploadsController < ApplicationController
   respond_to :json
 
   def index
+    epix_user_id = current_epix_user && current_epix_user.id
     @annual_report_uploads =
-      Sapi::Trade::AnnualReportUpload.all.map do |aru|
+      Sapi::Trade::AnnualReportUpload.created_by(epix_user_id).map do |aru|
         AnnualReportUploadSerializer.new(aru)
       end
   end

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,0 +1,7 @@
+class AnnualReportUploadsController < ApplicationController
+  respond_to :json
+
+  def index
+    @annual_report_uploads = Sapi::Trade::AnnualReportUpload.all
+  end
+end

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -4,8 +4,13 @@ class AnnualReportUploadsController < ApplicationController
   def index
     epix_user_id = current_epix_user && current_epix_user.id
     @annual_report_uploads =
-      Sapi::Trade::AnnualReportUpload.created_by(epix_user_id).map do |aru|
+      Sapi::Trade::AnnualReportUpload.created_by(epix_user_id)
+    @submitted_uploads = @annual_report_uploads.submitted.map do |aru|
         AnnualReportUploadSerializer.new(aru)
-      end
+    end
+
+    @in_progress_uploads = @annual_report_uploads.in_progress.map do |aru|
+        AnnualReportUploadSerializer.new(aru)
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  def after_sign_in_path_for(resource)
+    sign_in_url = if resource.is_a?(Epix::User)
+                    new_epix_user_session_url
+                  else
+                    new_sapi_user_session_url
+                  end
+    if request.referer.slice(0..(request.referer.index('?')-1)) == sign_in_url
+      annual_report_uploads_path
+    else
+      stored_location_for(resource) || request.referer || root_path
+    end
+  end
 end

--- a/app/models/epix/user.rb
+++ b/app/models/epix/user.rb
@@ -2,5 +2,6 @@ module Epix
   class User < Epix::Base
     devise :database_authenticatable, :registerable,
            :recoverable, :rememberable, :trackable, :validatable
+    has_many :annual_report_uploads, class_name: Sapi::Trade::AnnualReportUpload, foreign_key: :epix_created_by_id
   end
 end

--- a/app/models/sapi/geo_entity.rb
+++ b/app/models/sapi/geo_entity.rb
@@ -1,0 +1,5 @@
+module Sapi
+  class GeoEntity < Sapi::Base
+    belongs_to :geo_entity_type, class_name: Sapi::GeoEntityType
+  end
+end

--- a/app/models/sapi/geo_entity_type.rb
+++ b/app/models/sapi/geo_entity_type.rb
@@ -1,0 +1,4 @@
+module Sapi
+  class GeoEntityType < Sapi::Base
+  end
+end

--- a/app/models/sapi/trade/annual_report_upload.rb
+++ b/app/models/sapi/trade/annual_report_upload.rb
@@ -1,5 +1,7 @@
 module Sapi
   class Trade::AnnualReportUpload < Sapi::Base
     self.table_name = 'trade_annual_report_uploads'
+
+    scope :created_by, -> (user_id) { where({created_by_id: user_id, is_from_epix: true}) if user_id }
   end
 end

--- a/app/models/sapi/trade/annual_report_upload.rb
+++ b/app/models/sapi/trade/annual_report_upload.rb
@@ -1,0 +1,5 @@
+module Sapi
+  class Trade::AnnualReportUpload < Sapi::Base
+    self.table_name = 'trade_annual_report_uploads'
+  end
+end

--- a/app/models/sapi/trade/annual_report_upload.rb
+++ b/app/models/sapi/trade/annual_report_upload.rb
@@ -2,6 +2,8 @@ module Sapi
   class Trade::AnnualReportUpload < Sapi::Base
     self.table_name = 'trade_annual_report_uploads'
 
-    scope :created_by, -> (user_id) { where({created_by_id: user_id, is_from_epix: true}) if user_id }
+    belongs_to :trading_country, class_name: Sapi::GeoEntity, foreign_key: :trading_country_id
+
+    scope :created_by, -> (user_id) { where(epix_created_by_id: user_id) if user_id }
   end
 end

--- a/app/models/sapi/trade/annual_report_upload.rb
+++ b/app/models/sapi/trade/annual_report_upload.rb
@@ -5,5 +5,7 @@ module Sapi
     belongs_to :trading_country, class_name: Sapi::GeoEntity, foreign_key: :trading_country_id
 
     scope :created_by, -> (user_id) { where(epix_created_by_id: user_id) if user_id }
+    scope :submitted, -> { where("submitted_by_id IS NOT NULL") }
+    scope :in_progress, -> { where("submitted_by_id IS NULL") }
   end
 end

--- a/app/models/sapi/user.rb
+++ b/app/models/sapi/user.rb
@@ -2,5 +2,6 @@ module Sapi
   class User < Sapi::Base
     devise :database_authenticatable, :registerable,
            :recoverable, :rememberable, :trackable, :validatable
+    has_many :annual_report_uploads, class_name: Sapi::Trade::AnnualReportUpload, foreign_key: :created_by_id
   end
 end

--- a/app/serializers/annual_report_upload_serializer.rb
+++ b/app/serializers/annual_report_upload_serializer.rb
@@ -1,0 +1,26 @@
+class AnnualReportUploadSerializer < ActiveModel::Serializer
+  attributes :id, :trading_country_id, :point_of_view, :number_of_rows,
+  :file_name, :is_done, :created_at, :updated_at, :created_by, :updated_by
+
+  def file_name
+    object.csv_source_file.try(:path) && File.basename(object.csv_source_file.path)
+  end
+
+  def created_at
+    object.created_at.strftime("%d/%m/%y")
+  end
+
+  def updated_at
+    object.updated_at.strftime("%d/%m/%y")
+  end
+
+  def created_by
+    object.created_by && object.created_by.name
+  end
+
+  def updated_by
+    object.created_by && object.updated_by.name
+  end
+
+end
+

--- a/app/views/annual_report_uploads/index.html.erb
+++ b/app/views/annual_report_uploads/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Annual Report Uploads</h1>
+
+<%= react_component 'AnnualReportUploads', {data: @annual_report_uploads} %>

--- a/app/views/annual_report_uploads/index.html.erb
+++ b/app/views/annual_report_uploads/index.html.erb
@@ -1,3 +1,10 @@
 <h1>Annual Report Uploads</h1>
 
-<%= react_component 'AnnualReportUploads', {data: @annual_report_uploads} %>
+<h2>Uploads in progress</h2>
+<div class="in-progress-uploads">
+  <%= react_component 'AnnualReportUploads', {data: @in_progress_uploads} %>
+</div>
+<h2>Submitted uploads</h2>
+<div class="submitted-uploads">
+  <%= react_component 'AnnualReportUploads', {data: @submitted_uploads} %>
+</div>

--- a/app/views/annual_report_uploads/unauthorised.html.erb
+++ b/app/views/annual_report_uploads/unauthorised.html.erb
@@ -1,0 +1,8 @@
+<h1>You are not authorised to access this page.</h1>
+
+<h3>
+  Please login via
+  <%= link_to "EPIX", new_epix_user_session_path %>,
+  or via
+  <%= link_to "Species+", new_sapi_user_session_path %>
+</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       },
       class_name: Sapi::User
     }
+
   end
 
   namespace :epix do
@@ -16,6 +17,8 @@ Rails.application.routes.draw do
       class_name: Epix::User
     }
   end
+
+  resources :annual_report_uploads, only: [:index]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'home#index'
 end

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
     end
 
     context "when logging in from sapi" do
-      it "should show uploads from epix user" do
+      it "should show uploads from sapi user" do
         @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
         sign_in @sapi_user
         get :index

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe AnnualReportUploadsController, type: :controller do
+  describe "GET index" do
+    before(:each) do
+      @epix_user = FactoryGirl.create(:epix_user)
+      @sapi_user = FactoryGirl.create(:sapi_user)
+      @epix_upload = FactoryGirl.create(:annual_report_upload, epix_created_by_id: @epix_user.id)
+      2.times { FactoryGirl.create(:annual_report_upload, created_by_id: @sapi_user.id) }
+    end
+
+    context "when logging in from epix" do
+      it "should show uploads from epix user" do
+        @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+        sign_in @epix_user
+        get :index
+
+        expect(assigns(:annual_report_uploads).size).to eq(1)
+      end
+    end
+
+    context "when logging in from sapi" do
+      it "should show uploads from epix user" do
+        @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+        sign_in @sapi_user
+        get :index
+
+        expect(assigns(:annual_report_uploads).size).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
       @epix_user = FactoryGirl.create(:epix_user)
       @sapi_user = FactoryGirl.create(:sapi_user)
       @epix_upload = FactoryGirl.create(:annual_report_upload, epix_created_by_id: @epix_user.id)
-      2.times { FactoryGirl.create(:annual_report_upload, created_by_id: @sapi_user.id) }
+      2.times {
+        FactoryGirl.create(
+          :annual_report_upload,
+          created_by_id: @sapi_user.id,
+          submitted_by_id: @sapi_user.id
+        )
+      }
     end
 
     context "when logging in from epix" do
@@ -26,6 +32,24 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
         get :index
 
         expect(assigns(:annual_report_uploads).size).to eq(3)
+      end
+    end
+
+    context "filter by submitted and in progress" do
+      it "should assign only submitted uploads" do
+        @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+        sign_in @sapi_user
+        get :index
+
+        expect(assigns(:submitted_uploads).size).to eq(2)
+      end
+
+      it "should assign only in progress uploads" do
+        @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+        sign_in @sapi_user
+        get :index
+
+        expect(assigns(:in_progress_uploads).size).to eq(1)
       end
     end
   end

--- a/spec/controllers/epix_user/sessions_controller_spec.rb
+++ b/spec/controllers/epix_user/sessions_controller_spec.rb
@@ -4,14 +4,20 @@ RSpec.describe EpixUser::SessionsController, type: :controller do
   describe "GET new" do
     before(:each) do
       @user = FactoryGirl.create(:epix_user)
+      @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+      @request.env['HTTP_REFERER'] = 'http://test.host/epix/users/sign_in?user="email"'
+      sign_in @user
     end
     it "should use Epix::User as resource to login" do
-      @request.env['devise.mapping'] = Devise.mappings[:epix_user]
-      sign_in @user
       get :new
 
-      expect(response.status).to eq(302)
       expect(subject.current_epix_user.class).to eq(Epix::User)
+    end
+
+    it "should redirect to annual report uploads index page" do
+      get :new
+
+      expect(response).to redirect_to(annual_report_uploads_path)
     end
   end
 end

--- a/spec/controllers/sapi_user/sessions_controller_spec.rb
+++ b/spec/controllers/sapi_user/sessions_controller_spec.rb
@@ -4,14 +4,20 @@ RSpec.describe SapiUser::SessionsController, type: :controller do
   describe "GET new" do
     before(:each) do
       @user = FactoryGirl.create(:sapi_user)
+      @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+      @request.env['HTTP_REFERER'] = 'http://test.host/sapi/users/sign_in?user="email"'
+      sign_in @user
     end
     it "should use Epix::User as resource to login" do
-      @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
-      sign_in @user
       get :new
 
-      expect(response.status).to eq(302)
       expect(subject.current_sapi_user.class).to eq(Sapi::User)
+    end
+
+    it "should redirect to annual report uploads index page" do
+      get :new
+
+      expect(response).to redirect_to(annual_report_uploads_path)
     end
   end
 end

--- a/spec/factories/annual_report_uploads.rb
+++ b/spec/factories/annual_report_uploads.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :annual_report_upload, class: Sapi::Trade::AnnualReportUpload do
+    trading_country
+    point_of_view 'E'
+  end
+end

--- a/spec/factories/geo_entities.rb
+++ b/spec/factories/geo_entities.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :geo_entity_type, class: Sapi::GeoEntityType do
+    name 'COUNTRY'
+  end
+
+  factory :geo_entity, :aliases => [:trading_country], class: Sapi::GeoEntity do
+    geo_entity_type
+    name_en 'Wonderland'
+    sequence(:iso_code2) { |n| [n, n + 1].map { |i| (65 + i % 26).chr }.join }
+    is_current true
+  end
+end


### PR DESCRIPTION
This is related to [Index page for current & past submissions - CITES Party view](https://www.pivotaltracker.com/story/show/132315153).
It adds the AnnualReportUpload model from SAPI with controller, serializer and index page.
It also adds React for the rendering of the uploads once they are fetched and filtered by the controller.
SAPI structure.sql has been updated and some specs added.

This is just the basic structure of the index page to show that the filtering is working across SAPI and EPIX logins. So if logging in from SAPI then all the report uploads will be rendered, otherwise they will be filtered by EPIX user.
If the user is not logged in, it will be redirect to a page where to select a login. 