### PR TITLE
Changes design in sandbox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'appsignal', '~> 1.1.9'
 # Internationalisation for javascript
 gem "i18n-js", ">= 3.0.0.rc11"
 
+# Models versioning
+gem 'paper_trail', '~> 5.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,9 @@ GEM
       mini_portile2 (~> 2.1.0)
     nori (2.6.0)
     orm_adapter (0.5.0)
+    paper_trail (5.2.2)
+      activerecord (>= 3.0, < 6.0)
+      request_store (~> 1.1)
     pg (0.19.0)
     rack (2.0.1)
     rack-protection (1.5.3)
@@ -223,6 +226,7 @@ GEM
       railties (>= 3.2)
       tilt
     redis (3.3.1)
+    request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.4)
@@ -341,6 +345,7 @@ DEPENDENCIES
   letter_opener
   listen (~> 3.0.5)
   nested-hstore
+  paper_trail (~> 5.0)
   pg
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -11,10 +11,11 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
   render: ->
     data = @state.shipment
     keys = Object.keys(@state.changes)
+    changes = if keys.length > 1 then ' changes' else ' change'
     tr({ className: @state.rowType },
       td({}
-        div({}, data.updated_at)
-        div({}, keys.length + " changes")
+        div({ className: 'bold' }, data.updated_at)
+        div({ className: 'italic' }, keys.length + changes)
       )
       td({}, span({ className: 'appendix' }, data.appendix))
       td({},

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -1,18 +1,20 @@
 {div, a, i, tr, td} = React.DOM
-window.Shipment = class Shipment extends React.Component
+window.ShipmentVersion = class ShipmentVersion extends React.Component
   constructor: (props, context) ->
     super(props, context)
     @state = {
       shipment: props.shipment
+      changes: props.changes
       rowType: props.rowType
-      changesHistory: props.changesHistory
     }
 
   render: ->
     data = @state.shipment
     tr({ className: @state.rowType },
-      if @state.changesHistory
-        td({}, '')
+      td({}
+        div({}, data.updated_at)
+        div({}, Object.keys(@state.changes).length + " changes")
+      )
       td({}, data.appendix)
       td({},
         div(
@@ -31,23 +33,4 @@ window.Shipment = class Shipment extends React.Component
       td({}
         data.purpose_code + ' - ' + data.source_code + ' - ' + data.year
       )
-      unless @state.changesHistory
-        td({ className: 'actions-col' },
-          div(
-            {}
-            a(
-              { className: 'green-link-underlined' }
-              i({ className: 'fa fa-pencil-square-o'})
-              " #{I18n.t('edit')}"
-            )
-          )
-          div(
-            {}
-            a(
-              { className: 'green-link-underlined' }
-              i({ className: 'fa fa-times' })
-              " #{I18n.t('delete')}"
-            )
-          )
-        )
     )

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -1,4 +1,4 @@
-{div, a, i, tr, td} = React.DOM
+{div, a, i, tr, td, span} = React.DOM
 window.ShipmentVersion = class ShipmentVersion extends React.Component
   constructor: (props, context) ->
     super(props, context)
@@ -10,27 +10,41 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
 
   render: ->
     data = @state.shipment
+    keys = Object.keys(@state.changes)
     tr({ className: @state.rowType },
       td({}
         div({}, data.updated_at)
-        div({}, Object.keys(@state.changes).length + " changes")
+        div({}, keys.length + " changes")
       )
-      td({}, data.appendix)
+      td({}, span({ className: 'appendix' }, data.appendix))
       td({},
         div(
-          { className: 'bold' }
+          { className: 'taxon_name bold' }
           data.taxon_name
         )
-        div({}, data.taxon_name) # Replace with accepted_name
+        div({ className: 'accepted-name' }, data.taxon_name) # Replace with accepted_name
       )
-      td({}, data.term)
-      td({}, data.quantity)
-      td({}, data.trading_partner)
-      td({}, data.country_of_origin)
-      td({}, data.import_permit)
-      td({}, data.export_permit)
-      td({}, data.origin_permit)
+      td({}, span({ className: 'term' }, data.term))
+      td({}, span({ className: 'quantity' }, data.quantity))
+      td({}, span({ className: 'trading_partner' }, data.trading_partner))
+      td({}, span({ className: 'country_of_origin' }, data.country_of_origin))
+      td({}, span({ className: 'import_permit' }, data.import_permit))
+      td({}, span({ className: 'export_permit' }, data.export_permit))
+      td({}, span({ className: 'origin_permit' }, data.origin_permit))
       td({}
-        data.purpose_code + ' - ' + data.source_code + ' - ' + data.year
+        span({ className: 'purpose_code'}, data.purpose_code)
+        ' - '
+        span({ className: 'source_code' }, data.source_code)
+        ' - '
+        span({ className: 'year' }, + data.year)
       )
     )
+
+  componentDidMount: ->
+    keys = Object.keys(@state.changes)
+    for key in keys
+      regex = new RegExp(".*#{key}.*")
+      $('td span').filter( ->
+        if $(@).attr('class') && $(@).attr('class').match(regex)
+          $(@).addClass('changed')
+      )

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -5,7 +5,8 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
     @state = {
       pageName: props.pageName,
       totalPages: props.totalPages,
-      page: 1
+      page: 1,
+      annualReportUploadId: props.annualReportUploadId
     }
     @incrementPage = @changePage.bind(@, 1)
     @decrementPage = @changePage.bind(@, -1)
@@ -26,10 +27,15 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
   renderHead: ->
     thead({},
       tr({},
+        if @state.annualReportUploadId
+          th({}
+            div({}, 'Reference')
+            div({ className: 'subtitle' }, 'Change time')
+          )
         th({}, 'Appendix')
         th({},
           div({}, 'Taxon Name')
-          div({ className: 'accepted-name' }, 'Accepted Taxon Name')
+          div({ className: 'subtitle' }, 'Accepted Taxon Name')
         )
         th({}, 'Term')
         th({}, 'Qty')
@@ -55,16 +61,18 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
           div({}, 'Source-')
           div({}, 'Year')
         )
-        th({}, 'Actions')
+        unless @state.annualReportUploadId
+          th({}, 'Actions')
       )
     )
 
   renderBody: ->
     React.createElement(Shipments,
       {
-        key: @state.pageName,
-        pageName: @state.pageName,
+        key: @state.pageName
+        pageName: @state.pageName
         page: @state.page
+        annualReportUploadId: @state.annualReportUploadId
       }
     )
 

--- a/app/assets/stylesheets/sandbox.scss
+++ b/app/assets/stylesheets/sandbox.scss
@@ -1,5 +1,6 @@
 .sandbox-header {
-  margin: 35px 0;
+  margin: 35px 0 0;
+  h1.sandbox-title { border: 0; }
 }
 h1.sandbox-title {
   span {
@@ -10,10 +11,15 @@ h1.sandbox-title {
   margin: 0;
 }
 h3.sandbox-upload-summary {
+  margin: 0 0 35px 0;
   border-bottom: 3px solid $light-grey;
   font-weight: normal;
-  margin: 0;
   color: $main-blue;
+  &.no-border {
+    border: 0;
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .sandbox-body {
@@ -149,7 +155,7 @@ h3.sandbox-upload-summary {
       margin: 0 0 10px;
     }
     .permit-col-name { padding: 0 30px 0 0; }
-    .accepted-name { font-weight: normal; }
+    .subtitle { font-weight: normal; }
     .empty-col { padding: 0 0 40px 0; }
     tr { vertical-align: top; }
     th { padding: 10px 15px 0; }
@@ -209,3 +215,5 @@ h3.sandbox-upload-summary {
   position: relative;
   top: 32px;
 }
+
+.changes-link { height: 0; }

--- a/app/assets/stylesheets/sandbox.scss
+++ b/app/assets/stylesheets/sandbox.scss
@@ -173,6 +173,10 @@ h3.sandbox-upload-summary {
     .actions-col {
       div { padding: 0 0 5px 0; }
     }
+    span.changed {
+      background: $pink;
+      padding: 5px 7px;
+    }
   }
 }
 

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -32,11 +32,11 @@ class AnnualReportUploadsController < ApplicationController
       ShowAnnualReportUploadSerializer.new(annual_report_upload)
   end
 
-  # TODO get shipments by Annual Report Uploads
   def changes_history
     @annual_report_upload = Trade::AnnualReportUpload.find(params[:id])
-    shipments = Trade::SandboxTemplate.joins(
-      "JOIN versions v on v.item_id = trade_sandbox_template.id"
+    ar_klass = @annual_report_upload.sandbox.ar_klass
+    shipments = ar_klass.joins(
+      "JOIN versions v on v.item_id = #{ar_klass.table_name}.id"
     ).uniq
     per_page = Trade::SandboxTemplate.per_page
     @total_pages = (shipments.count / per_page.to_f).ceil

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -32,6 +32,16 @@ class AnnualReportUploadsController < ApplicationController
       ShowAnnualReportUploadSerializer.new(annual_report_upload)
   end
 
+  # TODO get shipments by Annual Report Uploads
+  def changes_history
+    @annual_report_upload = Trade::AnnualReportUpload.find(params[:id])
+    shipments = Trade::SandboxTemplate.joins(
+      "JOIN versions v on v.item_id = trade_sandbox_template.id"
+    ).uniq
+    per_page = Trade::SandboxTemplate.per_page
+    @total_pages = (shipments.count / per_page.to_f).ceil
+  end
+
   private
 
   def authenticate_user!

--- a/app/controllers/api/v1/annual_report_uploads_controller.rb
+++ b/app/controllers/api/v1/annual_report_uploads_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::AnnualReportUploadsController < ApplicationController
     ).uniq
     @shipments = shipments.paginate(
       page: params[:shipments]).map do |shipment|
-        SandboxShipmentSerializer.new(shipment)
+        SandboxShipmentChangesSerializer.new(shipment)
       end
 
     render json: {

--- a/app/controllers/api/v1/annual_report_uploads_controller.rb
+++ b/app/controllers/api/v1/annual_report_uploads_controller.rb
@@ -23,10 +23,11 @@ class Api::V1::AnnualReportUploadsController < ApplicationController
     }
   end
 
-  # TODO get shipments by Annual Report Upload
   def changes_history
-    shipments = Trade::SandboxTemplate.all.joins(
-      "JOIN versions v ON v.item_id = trade_sandbox_template.id"
+    @annual_report_upload = Trade::AnnualReportUpload.find(params[:id])
+    ar_klass = @annual_report_upload.sandbox.ar_klass
+    shipments = ar_klass.joins(
+      "JOIN versions v on v.item_id = #{ar_klass.table_name}.id"
     ).uniq
     @shipments = shipments.paginate(
       page: params[:shipments]).map do |shipment|

--- a/app/controllers/api/v1/annual_report_uploads_controller.rb
+++ b/app/controllers/api/v1/annual_report_uploads_controller.rb
@@ -23,6 +23,21 @@ class Api::V1::AnnualReportUploadsController < ApplicationController
     }
   end
 
+  # TODO get shipments by Annual Report Upload
+  def changes_history
+    shipments = Trade::SandboxTemplate.all.joins(
+      "JOIN versions v ON v.item_id = trade_sandbox_template.id"
+    ).uniq
+    @shipments = shipments.paginate(
+      page: params[:shipments]).map do |shipment|
+        SandboxShipmentSerializer.new(shipment)
+      end
+
+    render json: {
+      shipments: @shipments
+    }
+  end
+
   private
 
   def authenticate_user!

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,0 +1,5 @@
+module PaperTrail
+  class Version < Sapi::Base
+    include PaperTrail::VersionConcern
+  end
+end

--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -3,8 +3,6 @@ class Trade::SandboxTemplate < Sapi::Base
   self.per_page = 10
   self.table_name = :trade_sandbox_template
 
-  has_paper_trail
-
   COLUMNS_IN_CSV_ORDER = [
     "appendix", "species_name", "term_code", "quantity", "unit_code",
     "trading_partner", "country_of_origin", "import_permit", "export_permit",
@@ -25,6 +23,7 @@ class Trade::SandboxTemplate < Sapi::Base
       klass = Class.new(Sapi::Base) do
         self.table_name = table_name
         include ActiveModel::ForbiddenAttributesProtection
+        has_paper_trail
         # belongs_to :taxon_concept
         # belongs_to :reported_taxon_concept, :class_name => TaxonConcept
 

--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -3,6 +3,8 @@ class Trade::SandboxTemplate < Sapi::Base
   self.per_page = 10
   self.table_name = :trade_sandbox_template
 
+  has_paper_trail
+
   COLUMNS_IN_CSV_ORDER = [
     "appendix", "species_name", "term_code", "quantity", "unit_code",
     "trading_partner", "country_of_origin", "import_permit", "export_permit",

--- a/app/serializers/sandbox_shipment_changes_serializer.rb
+++ b/app/serializers/sandbox_shipment_changes_serializer.rb
@@ -21,7 +21,7 @@ class SandboxShipmentChangesSerializer < ActiveModel::Serializer
 
   def changes
     object.versions.map(&:changeset).each do |changes|
-      changes.delete("updated_at")
+      changes.delete("updated_at") if changes.present?
     end
   end
 

--- a/app/serializers/sandbox_shipment_changes_serializer.rb
+++ b/app/serializers/sandbox_shipment_changes_serializer.rb
@@ -1,8 +1,8 @@
-class SandboxShipmentVersionSerializer < ActiveModel::Serializer
+class SandboxShipmentChangesSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit, :updated_at
+    :year, :import_permit, :versions, :changes, :updated_at
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -13,8 +13,20 @@ class SandboxShipmentVersionSerializer < ActiveModel::Serializer
 #    object.taxon_concept && "#{object.taxon_concept.full_name} (#{object.taxon_concept.name_status})"
 #  end
   #
+  def versions
+    object.versions.map(&:reify).map do |version|
+      SandboxShipmentSerializer.new(version)
+    end
+  end
+
+  def changes
+    object.versions.map(&:changeset).each do |changes|
+      changes.delete("updated_at")
+    end
+  end
+
   def updated_at
-    object.updated_at.strftime("%d/%m/%Y")
+    object.updated_at.strftime("%d/%m/%y")
   end
 
 end

--- a/app/serializers/sandbox_shipment_serializer.rb
+++ b/app/serializers/sandbox_shipment_serializer.rb
@@ -2,7 +2,7 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit
+    :year, :import_permit, :versions, :changes
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -12,6 +12,14 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
 #  def accepted_taxon_name
 #    object.taxon_concept && "#{object.taxon_concept.full_name} (#{object.taxon_concept.name_status})"
 #  end
+  #
+  def versions
+    object.versions.map(&:reify)
+  end
+
+  def changes
+    object.versions.map(&:changeset)
+  end
 
 end
 

--- a/app/serializers/sandbox_shipment_serializer.rb
+++ b/app/serializers/sandbox_shipment_serializer.rb
@@ -2,7 +2,7 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit, :versions, :changes, :updated_at
+    :year, :import_permit, :updated_at
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -13,18 +13,6 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
 #    object.taxon_concept && "#{object.taxon_concept.full_name} (#{object.taxon_concept.name_status})"
 #  end
   #
-  def versions
-    object.versions.map(&:reify).map do |version|
-      SandboxShipmentVersionSerializer.new(version)
-    end
-  end
-
-  def changes
-    object.versions.map(&:changeset).each do |changes|
-      changes.delete("updated_at")
-    end
-  end
-
   def updated_at
     object.updated_at.strftime("%d/%m/%y")
   end

--- a/app/serializers/sandbox_shipment_serializer.rb
+++ b/app/serializers/sandbox_shipment_serializer.rb
@@ -18,7 +18,9 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
   end
 
   def changes
-    object.versions.map(&:changeset)
+    object.versions.map(&:changeset).each do |changes|
+      changes.delete("updated_at")
+    end
   end
 
 end

--- a/app/serializers/sandbox_shipment_version_serializer.rb
+++ b/app/serializers/sandbox_shipment_version_serializer.rb
@@ -1,8 +1,8 @@
-class SandboxShipmentSerializer < ActiveModel::Serializer
+class SandboxShipmentVersionSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit, :versions, :changes, :updated_at
+    :year, :import_permit, :updated_at
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -13,20 +13,8 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
 #    object.taxon_concept && "#{object.taxon_concept.full_name} (#{object.taxon_concept.name_status})"
 #  end
   #
-  def versions
-    object.versions.map(&:reify).map do |version|
-      SandboxShipmentVersionSerializer.new(version)
-    end
-  end
-
-  def changes
-    object.versions.map(&:changeset).each do |changes|
-      changes.delete("updated_at")
-    end
-  end
-
   def updated_at
-    object.updated_at.strftime("%d/%m/%y")
+    object.updated_at.strftime("%d/%m/%Y")
   end
 
 end

--- a/app/views/annual_report_uploads/changes_history.html.erb
+++ b/app/views/annual_report_uploads/changes_history.html.erb
@@ -2,6 +2,14 @@
 <h3 class="sandbox-upload-summary no-border">
   <%= @annual_report_upload.summary %>
 </h3>
+<div class="align-right batch-edit-link">
+  <i class="fa fa-download green"></i>
+  <%=
+    link_to t('download_changes_history'),
+    '',
+    class: 'green-link-underlined'
+  %>
+</div>
 <h1 class="sandbox-title">Changes History</h1>
 
 <%=

--- a/app/views/annual_report_uploads/changes_history.html.erb
+++ b/app/views/annual_report_uploads/changes_history.html.erb
@@ -1,0 +1,14 @@
+<%= render "shared/back_to_shipments" %>
+<h3 class="sandbox-upload-summary no-border">
+  <%= @annual_report_upload.summary %>
+</h3>
+<h1 class="sandbox-title">Changes History</h1>
+
+<%=
+  react_component 'ShipmentsTable',
+    {
+      pageName: 'shipments',
+      totalPages: @total_pages,
+      annualReportUploadId: @annual_report_upload.id,
+    }
+%>

--- a/app/views/annual_report_uploads/show.html.erb
+++ b/app/views/annual_report_uploads/show.html.erb
@@ -1,9 +1,18 @@
 <div class="sandbox-header">
   <h1 class="sandbox-title"><%= t('annual_report_upload') %> <span>SANDBOX</span></h1>
-  <h3 class="sandbox-upload-summary">
-    <%= @annual_report_upload.summary %>
-  </h3>
 </div>
+
+<div class="align-right changes-link">
+  <%=
+    link_to t('see_changes_history'),
+      changes_history_path(@annual_report_upload.object.id),
+      class: 'green-link-underlined'
+  %>
+</div>
+
+<h3 class="sandbox-upload-summary">
+  <%= @annual_report_upload.summary %>
+</h3>
 
 <div class="sandbox-body">
   <%= download_and_submit %>

--- a/app/views/shared/_back_to_shipments.html.erb
+++ b/app/views/shared/_back_to_shipments.html.erb
@@ -1,0 +1,5 @@
+<div class='back-to-shipments'>
+  <i class='fa fa-long-arrow-left green'></i>
+  <%= link_to t('back_to_shipments'), '', class: 'green-link-underlined' %>
+</div>
+

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -1,8 +1,4 @@
-<div class='back-to-shipments'>
-  <i class='fa fa-long-arrow-left green'></i>
-  <%= link_to t('back_to_shipments'), '', class: 'green-link-underlined' %>
-</div>
-
+<%= render "shared/back_to_shipments" %>
 <div class='selected-error'>
   <span><%= t('selected_error') %>:</span><span class='bold'> Placeholder</span>
 </div>

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.config.track_associations = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   end
 
   resources :annual_report_uploads, only: [:index, :show]
+  get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history', as: 'changes_history'
   resources :shipments, only: [:index]
 
   wash_out "api/v1/cites_reporting"
@@ -26,6 +27,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :annual_report_uploads, only: [:index]
+      get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history'
       resources :shipments, only: [:index]
     end
   end

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -51,4 +51,68 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
       end
     end
   end
+
+  describe "GET show" do
+    before(:each) do
+      @epix_user = FactoryGirl.create(:epix_user)
+      @sapi_user = FactoryGirl.create(:sapi_user)
+      @epix_upload = FactoryGirl.create(:annual_report_upload, epix_creator: @epix_user)
+      2.times {
+        FactoryGirl.create(
+          :annual_report_upload,
+          created_by_id: @sapi_user.id,
+          submitted_by_id: @sapi_user.id,
+          submitted_at: DateTime.now
+        )
+      }
+    end
+
+    context "Initialise variables" do
+      it "should assign annual_report_upload" do
+        @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+        sign_in @epix_user
+
+        get :show, id: @epix_upload.id
+
+        expect(assigns(:annual_report_upload).present?).to be(true)
+      end
+    end
+  end
+
+  describe "GET changes_history" do
+    before(:each) do
+      @epix_user = FactoryGirl.create(:epix_user)
+      @sapi_user = FactoryGirl.create(:sapi_user)
+      @epix_upload = FactoryGirl.create(:annual_report_upload, epix_creator: @epix_user)
+      2.times {
+        FactoryGirl.create(
+          :annual_report_upload,
+          created_by_id: @sapi_user.id,
+          submitted_by_id: @sapi_user.id,
+          submitted_at: DateTime.now
+        )
+      }
+      @sanbox_template = FactoryGirl.create(:sandbox_template)
+    end
+
+    context "Initialise variables" do
+      it "should assign annual_report_upload" do
+        @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+        sign_in @epix_user
+
+        get 'changes_history', id: @epix_upload.id
+
+        expect(assigns(:annual_report_upload).present?).to be(true)
+      end
+    end
+
+    it "should assign total_pages", versioning: true do
+      @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+      sign_in @epix_user
+
+      get 'changes_history', id: @epix_upload.id
+
+      expect(assigns(:total_pages)).to eq(1)
+    end
+  end
 end

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -92,7 +92,30 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
           submitted_at: DateTime.now
         )
       }
-      @sanbox_template = FactoryGirl.create(:sandbox_template)
+      sandbox = @epix_upload.sandbox
+      sandbox.copy_data({
+        CITESReport: [
+          {
+            CITESReportRow:  {
+              TradingPartnerId:  "FR",
+              Year:  2016,
+              ScientificName:  "Alligator mississipiensis",
+              Appendix:  nil,
+              TermCode:  "SKI",
+              Quantity:  5.0,
+              UnitCode:  "KIL",
+              SourceCode:  "W",
+              PurposeCode:  "Z",
+              OriginCountryId:  "US",
+              OriginPermitId:  nil,
+              ExportPermitId:  "CH123",
+              ImportPermitId:  nil
+            }
+          }
+        ]
+      })
+      @sandbox_template = sandbox.ar_klass.first
+      @sandbox_template.update_attributes(year: 2015)
     end
 
     context "Initialise variables" do

--- a/spec/controllers/api/v1/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/api/v1/annual_report_uploads_controller_spec.rb
@@ -54,4 +54,33 @@ RSpec.describe Api::V1::AnnualReportUploadsController, type: :controller do
       end
     end
   end
+
+  describe "GET changes_history" do
+    before(:each) do
+      @epix_user = FactoryGirl.create(:epix_user)
+      @sapi_user = FactoryGirl.create(:sapi_user)
+      @epix_upload = FactoryGirl.create(:annual_report_upload, epix_creator: @epix_user)
+      2.times {
+        FactoryGirl.create(
+          :annual_report_upload,
+          created_by_id: @sapi_user.id,
+          submitted_by_id: @sapi_user.id,
+          submitted_at: DateTime.now
+        )
+      }
+      @sandbox_template = FactoryGirl.create(:sandbox_template, year: '2016')
+      @sandbox_template.update_attributes!(year: '2015')
+    end
+
+    #context "Retrieve shipments" do
+    #  it "should get shipments with changes only", versioning: true do
+    #    @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+    #    sign_in @sapi_user
+
+    #    get :changes_history, id: @epix_upload.id
+
+    #    expect(assigns(:shipments).size).to eq(1)
+    #  end
+    #end
+  end
 end

--- a/spec/controllers/api/v1/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/api/v1/annual_report_uploads_controller_spec.rb
@@ -68,19 +68,41 @@ RSpec.describe Api::V1::AnnualReportUploadsController, type: :controller do
           submitted_at: DateTime.now
         )
       }
-      @sandbox_template = FactoryGirl.create(:sandbox_template, year: '2016')
-      @sandbox_template.update_attributes!(year: '2015')
+      sandbox = @epix_upload.sandbox
+      sandbox.copy_data({
+        CITESReport: [
+          {
+            CITESReportRow:  {
+              TradingPartnerId:  "FR",
+              Year:  2016,
+              ScientificName:  "Alligator mississipiensis",
+              Appendix:  nil,
+              TermCode:  "SKI",
+              Quantity:  5.0,
+              UnitCode:  "KIL",
+              SourceCode:  "W",
+              PurposeCode:  "Z",
+              OriginCountryId:  "US",
+              OriginPermitId:  nil,
+              ExportPermitId:  "CH123",
+              ImportPermitId:  nil
+            }
+          }
+        ]
+      })
+      @sandbox_template = sandbox.ar_klass.first
+      @sandbox_template.update_attributes(year: 2015)
     end
 
-    #context "Retrieve shipments" do
-    #  it "should get shipments with changes only", versioning: true do
-    #    @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
-    #    sign_in @sapi_user
+    context "Retrieve shipments" do
+      it "should get shipments with changes only", versioning: true do
+        @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+        sign_in @sapi_user
 
-    #    get :changes_history, id: @epix_upload.id
+        get :changes_history, id: @epix_upload.id
 
-    #    expect(assigns(:shipments).size).to eq(1)
-    #  end
-    #end
+        expect(assigns(:shipments).size).to eq(1)
+      end
+    end
   end
 end

--- a/spec/models/trade/sandbox_template_spec.rb
+++ b/spec/models/trade/sandbox_template_spec.rb
@@ -1,23 +1,39 @@
 require "rails_helper"
 
 RSpec.describe Trade::SandboxTemplate, type: :model do
-  let(:sandbox_template) {
-    FactoryGirl.create(:sandbox_template, year: '2016')
+  let(:aru){ FactoryGirl.create(:annual_report_upload) }
+  let(:shipment){
+    sandbox = aru.sandbox
+    sandbox.copy_data({
+      CITESReport: [
+        {
+          CITESReportRow:  {
+            TradingPartnerId:  "FR",
+            Year:  2016,
+            ScientificName:  "Alligator mississipiensis",
+            Appendix:  nil,
+            TermCode:  "SKI",
+            Quantity:  5.0,
+            UnitCode:  "KIL",
+            SourceCode:  "W",
+            PurposeCode:  "Z",
+            OriginCountryId:  "US",
+            OriginPermitId:  nil,
+            ExportPermitId:  "CH123",
+            ImportPermitId:  nil
+          }
+        }
+      ]
+    })
+    sandbox.ar_klass.first
   }
-
-  describe :create do
-    it "generates a version with create event", versioning: true do
-      expect(sandbox_template.versions.size).to eq(1)
-      expect(sandbox_template.versions.last.event).to eq('create')
-    end
-  end
 
   describe :update do
     it "generates a version with update", versioning: true do
-      sandbox_template.update_attributes(year: '2015')
+      shipment.update_attributes(year: '2015')
 
-      expect(sandbox_template.versions.size).to eq(2)
-      expect(sandbox_template.versions.last.event).to eq('update')
+      expect(shipment.versions.size).to eq(1)
+      expect(shipment.versions.last.event).to eq('update')
     end
   end
 end

--- a/spec/models/trade/sandbox_template_spec.rb
+++ b/spec/models/trade/sandbox_template_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Trade::SandboxTemplate, type: :model do
+  let(:sandbox_template) {
+    FactoryGirl.create(:sandbox_template, year: '2016')
+  }
+
+  describe :create do
+    it "generates a version with create event", versioning: true do
+      expect(sandbox_template.versions.size).to eq(1)
+      expect(sandbox_template.versions.last.event).to eq('create')
+    end
+  end
+
+  describe :update do
+    it "generates a version with update", versioning: true do
+      sandbox_template.update_attributes(year: '2015')
+
+      expect(sandbox_template.versions.size).to eq(2)
+      expect(sandbox_template.versions.last.event).to eq('update')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,8 @@ require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'paper_trail/frameworks/rspec'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
This is about [Implement design for viewing changes in sandbox](https://www.pivotaltracker.com/story/show/133836795), but it also implements and manages the versioning using `paper_trail`.
The `Trade::SandboxTemplate` model uses paper_trail to keep track of the changes so that we can display those in the changes_history page. It's also possible to diff the changes thanks to the `changeset` field that has been added to the SAPI `versions` table.

Some of the logic still needs to be implemented, like the link between the AnnualReportUpload and the SandboxTemplate; the changes_history page  displays only the records for that AnnualReportUpload that contains changes.

Some specs have been added, but I couldn't successfully test the `changeset`, no matter how much I tried. I think it might be a good idea to make a PR out of these changes anyway, and apply those tests later on.