### PR TITLE
Redirect to root path if referer different from sign_in_url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
     if request.referer.slice(0..(referer_index)) == sign_in_url
       annual_report_uploads_path
     else
-      stored_location_for(resource) || request.referer || root_path
+      stored_location_for(resource) || root_path
     end
   end
 


### PR DESCRIPTION
This is for [Trade Reporting link doesn't work when user already logged in to trade reporting tool](https://www.pivotaltracker.com/story/show/135035313).
It fixes the `after_sign_in_path_for` method to redirect to `root_path` if the request url is different from the sign in url. So the trade report link now redirects to the correct place