### PR TITLE
Authorised user can delete aru

### DIFF
--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -27,7 +27,11 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
         else
           @renderWithSandbox(@state.annualReportUpload)
         a(
-          {className: 'delete-upload', href: '#'}
+          {
+            className: 'delete-upload',
+            href: "/annual_report_uploads/#{@state.annualReportUpload.id}",
+            "data-method": 'delete'
+          }
           i({className: 'fa fa-times'})
           I18n.t('delete')
         )

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,5 +1,6 @@
 class AnnualReportUploadsController < ApplicationController
   before_action :authenticate_user!
+  before_action :authorise_destroy, only: [:destroy]
   respond_to :json
 
   def index
@@ -44,16 +45,11 @@ class AnnualReportUploadsController < ApplicationController
 
   def destroy
     @annual_report_upload = Trade::AnnualReportUpload.find(params[:id])
-    deleted = true
-    unless @annual_report_upload.user_authorised_to_destroy?(current_user)
-      deleted = false
+    if @annual_report_upload.destroy_with_sandbox
+      flash[:notice] = t('aru_deleted')
     else
-      unless @annual_report_upload.submitted_at.present?
-        deleted = @annual_report_upload.sandbox.try(:destroy) &&
-          @annual_report_upload.destroy
-      end
+      flash[:alert] = t('aru_not_deleted')
     end
-    deleted ? flash[:notice] = t('aru_deleted') : flash[:alert] = t('aru_not_deleted')
     redirect_to annual_report_uploads_path
   end
 
@@ -61,6 +57,26 @@ class AnnualReportUploadsController < ApplicationController
 
   def authenticate_user!
     render "unauthorised" unless (current_epix_user || current_sapi_user).present?
+  end
+
+  def authorise_destroy
+    aru = Trade::AnnualReportUpload.find(params[:id])
+    creator = aru.creator
+    authorised = true
+    if creator.is_a?(Epix::User)
+      if current_user.is_a?(Sapi::User)
+        flash[:alert] = t('aru_not_deleted')
+        redirect_to annual_report_uploads_path and return true
+      end
+      authorised = (current_user.id == creator.id ||
+        (current_user.organisation.id == creator.organisation.id && current_user.is_admin))
+    else
+      authorised = current_user.is_a?(Sapi::User) && current_user.role == Sapi::User::MANAGER
+    end
+    if !authorised || aru.submitted_at.present?
+      flash[:alert] = t('aru_not_deleted')
+      redirect_to annual_report_uploads_path
+    end
   end
 
 end

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -64,14 +64,13 @@ class Trade::AnnualReportUpload < Sapi::Base
     sapi_creator || epix_creator
   end
 
-  def user_authorised_to_destroy?(user)
-    if creator.is_a?(Epix::User)
-      return false if user.is_a?(Sapi::User)
-      return (user.id == creator.id ||
-        (user.organisation.id == creator.organisation.id && user.is_admin))
-    else
-      return user.is_a?(Sapi::User) && user.role == 'admin'
+  def destroy_with_sandbox
+    destroyed = false
+    self.transaction do
+      self.sandbox.try(:destroy)
+      destroyed = self.destroy
     end
+    destroyed
   end
 
   def process_validation_rules

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -60,6 +60,20 @@ class Trade::AnnualReportUpload < Sapi::Base
     point_of_view == 'E'
   end
 
+  def creator
+    sapi_creator || epix_creator
+  end
+
+  def user_authorised_to_destroy?(user)
+    if creator.is_a?(Epix::User)
+      return false if user.is_a?(Sapi::User)
+      return (user.id == creator.id ||
+        (user.organisation.id == creator.organisation.id && user.is_admin))
+    else
+      return user.is_a?(Sapi::User) && user.role == 'admin'
+    end
+  end
+
   def process_validation_rules
     @primary_validation_errors = run_validations(
       Trade::ValidationRule.where(is_primary: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,3 +49,5 @@ en:
   back_to_epix: 'Back to EPIX'
   back_to_speciesplus: 'Back to Species+'
   unauthorised: "You are not authorised to access this resource."
+  aru_deleted: 'Annual Report Upload successfully deleted.'
+  aru_not_deleted: 'Cannot delete Annual Report Upload.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     }
   end
 
-  resources :annual_report_uploads, only: [:index, :show]
+  resources :annual_report_uploads, only: [:index, :show, :destroy]
   get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history', as: 'changes_history'
   resources :shipments, only: [:index]
 


### PR DESCRIPTION
This is about [Authorised user can delete a sandbox](https://www.pivotaltracker.com/story/show/135319495).
The authorisation check is done via a method in the AnnuaReportUpload model, while the controller just handles the flash messages and the redirect to the index page.
If a sandbox exists that is destroyed before the AnnualReportUpload itself.