### PR TITLE
Download error report

### DIFF
--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -7,11 +7,13 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       submitted: !!props.annualReportUpload.submitted_at
       sandboxEnabled: !!props.sandboxEnabled
     }
-    @changeFile = @updateModal.bind(@, @summary())
+    @updateModal = @updateModal.bind(@, @summary())
 
   updateModal: (filename) ->
     $('#download_modal .file-to-download').html(filename)
     download_button = $('#download_modal .download-button')
+    modal_content = $('#download_modal .modal-content')
+    info_text = $('#download_modal .info-text')
     download_button.attr('href',
       "/annual_report_uploads/#{@state.annualReportUpload.id}/download_error_report"
     )
@@ -19,6 +21,16 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       download_button.removeClass('disabled')
     else
       download_button.addClass('disabled')
+    if @state.submitted
+      modal_content.addClass('smaller')
+      text = I18n.t('submitted_at_info_box') + " #{@state.annualReportUpload.submitted_by} "
+      text = text + I18n.t('the') + " #{@state.annualReportUpload.submitted_at}"
+      info_text.html(text)
+    else
+      modal_content.removeClass('smaller')
+      info_text.html(I18n.t('change_sandbox_settings'))
+
+
 
 
   render: ->
@@ -53,7 +65,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
         href: '#',
         "data-toggle": "modal",
         "data-target": "#download_modal",
-        onClick: @changeFile,
+        onClick: @updateModal,
       }
       @summary()
     )

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -11,9 +11,15 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
 
   updateModal: (filename) ->
     $('#download_modal .file-to-download').html(filename)
-    $('#download_modal .download-button').attr('href',
+    download_button = $('#download_modal .download-button')
+    download_button.attr('href',
       "/annual_report_uploads/#{@state.annualReportUpload.id}/download_error_report"
     )
+    if @state.annualReportUpload.has_validation_report
+      download_button.removeClass('disabled')
+    else
+      download_button.addClass('disabled')
+
 
   render: ->
     if @state.submitted

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -11,6 +11,9 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
 
   updateModal: (filename) ->
     $('#download_modal .file-to-download').html(filename)
+    $('#download_modal .download-button').attr('href',
+      "/annual_report_uploads/#{@state.annualReportUpload.id}/download_error_report"
+    )
 
   render: ->
     if @state.submitted

--- a/app/assets/javascripts/translations/en.js
+++ b/app/assets/javascripts/translations/en.js
@@ -20,6 +20,8 @@ I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}),
     "show_less_errors": "Show less errors",
     "edit": "Edit",
     "edit_all_errors": "Edit all affected errors",
-    "close": "Close"
+    "close": "Close",
+    "submitted_at_info_box": "This report has been submitted by",
+    "change_sandbox_settings": 'If you would like to correct these existing errors by using the app sandbox please update the relevant settings on <a href="#" class="bold">your admin account page.</a>'
   }
 )

--- a/app/assets/stylesheets/annual_report_upload.scss
+++ b/app/assets/stylesheets/annual_report_upload.scss
@@ -104,10 +104,6 @@ input.real-file-input {
   }
   .buttons { margin: 20px 0; }
   .button { padding: 9px 30px; }
-  .download-button.disabled {
-    opacity: 0.3;
-    pointer-events: none;
-  }
 }
 
 .annual-report-upload {

--- a/app/assets/stylesheets/annual_report_upload.scss
+++ b/app/assets/stylesheets/annual_report_upload.scss
@@ -80,6 +80,7 @@ input.real-file-input {
   .modal-content {
     width: 500px;
     height: 370px;
+    &.smaller { height: 310px; }
   }
   .change-sandbox-settings {
     background: $lightest-grey;
@@ -93,7 +94,7 @@ input.real-file-input {
     color: $main-blue;
     font-size: 18px;
   }
-  span {
+  span.info-text {
     position: relative;
     left: 10px;
     a {

--- a/app/assets/stylesheets/annual_report_upload.scss
+++ b/app/assets/stylesheets/annual_report_upload.scss
@@ -103,6 +103,10 @@ input.real-file-input {
   }
   .buttons { margin: 20px 0; }
   .button { padding: 9px 30px; }
+  .download-button.disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
 }
 
 .annual-report-upload {

--- a/app/assets/stylesheets/sandbox.scss
+++ b/app/assets/stylesheets/sandbox.scss
@@ -191,10 +191,6 @@ h3.sandbox-upload-summary {
 .shipments-dropdown, .shipments-input-box {
   color: $grey;
   div { margin: 5px 0 0; }
-  &.disabled {
-    opacity: 0.3;
-    pointer-events: none;
-  }
   button {
     min-height: 25px;
     background: white;

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -53,6 +53,14 @@ class AnnualReportUploadsController < ApplicationController
     redirect_to annual_report_uploads_path
   end
 
+  def download_error_report
+    aru = Trade::AnnualReportUpload.find(params[:id])
+    validation_report_csv_file = ValidationReportCsvGenerator.call(aru)
+    data = File.read(validation_report_csv_file)
+
+    send_data data, type: 'text/csv', filename: "validation_report_#{aru.id}.csv"
+  end
+
   private
 
   def authenticate_user!

--- a/app/helpers/sandbox_helper.rb
+++ b/app/helpers/sandbox_helper.rb
@@ -3,7 +3,7 @@ module SandboxHelper
     content_tag(:div, nil, class: 'download-and-submit') do
       content_tag(:div, nil, class: 'download-report') do
         content_tag(:i, nil, class: 'fa fa-download') +
-        link_to(t('download_report_on_errors'), '#', class: 'bold')
+        link_to(t('download_report_on_errors'), download_error_report_path, class: 'bold')
       end +
       content_tag(:div, nil, class: 'submit-shipments') do
         validation_errors = @annual_report_upload.validation_errors

--- a/app/helpers/sandbox_helper.rb
+++ b/app/helpers/sandbox_helper.rb
@@ -1,7 +1,9 @@
 module SandboxHelper
   def download_and_submit
+    download_disabled =
+      @annual_report_upload.has_validation_report ? '' : 'disabled'
     content_tag(:div, nil, class: 'download-and-submit') do
-      content_tag(:div, nil, class: 'download-report') do
+      content_tag(:div, nil, class: "download-report #{download_disabled}") do
         content_tag(:i, nil, class: 'fa fa-download') +
         link_to(t('download_report_on_errors'), download_error_report_path, class: 'bold')
       end +

--- a/app/serializers/annual_report_upload_serializer.rb
+++ b/app/serializers/annual_report_upload_serializer.rb
@@ -2,7 +2,7 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
   attributes :id, :trading_country_id, :point_of_view, :number_of_rows,
   :file_name, :created_at, :updated_at, :created_by, :updated_by,
   :submitted_at, :submitted_by,  :trading_country,
-  :number_of_records_submitted,
+  :number_of_records_submitted, :has_validation_report
 
   def file_name
     object.csv_source_file.try(:path) && File.basename(object.csv_source_file.path)
@@ -64,6 +64,10 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
 
   def trading_country
     object.trading_country && object.trading_country.name_en
+  end
+
+  def has_validation_report
+    object.validation_report.present?
   end
 
 end

--- a/app/serializers/show_annual_report_upload_serializer.rb
+++ b/app/serializers/show_annual_report_upload_serializer.rb
@@ -1,7 +1,7 @@
 class ShowAnnualReportUploadSerializer < ActiveModel::Serializer
   attributes :id, :trading_country_id, :point_of_view, :number_of_rows,
   :file_name, :has_primary_errors, :created_at, :updated_at,
-  :created_by, :updated_by, :summary,
+  :created_by, :updated_by, :summary, :has_validation_report,
   :validation_errors, :ignored_validation_errors
 
   def validation_errors
@@ -64,5 +64,9 @@ class ShowAnnualReportUploadSerializer < ActiveModel::Serializer
     object.trading_country.name_en + ' (' + object.point_of_view + '), ' +
       object.number_of_rows.to_s + ' shipments' + ' uploaded on ' + _created_at +
       ' by ' + _created_by + ' ('  + (file_name || '') + ')'
+  end
+
+  def has_validation_report
+    object.validation_report.present?
   end
 end

--- a/app/views/annual_report_uploads/_download_modal.html.erb
+++ b/app/views/annual_report_uploads/_download_modal.html.erb
@@ -9,7 +9,7 @@
       <p class="file-to-download"></p>
       <div class="change-sandbox-settings info-box">
         <i class="fa fa-info-circle"></i>
-        <span><%= t('change_sandbox_settings').html_safe %></span>
+        <span class="info-text"><%= t('change_sandbox_settings').html_safe %></span>
       </div>
       <div class="buttons right">
         <%=

--- a/app/views/annual_report_uploads/_download_modal.html.erb
+++ b/app/views/annual_report_uploads/_download_modal.html.erb
@@ -18,9 +18,7 @@
           )
         %>
         <%=
-          button_tag('Download',
-            {href: '#', class: 'download-button button' }
-          )
+          link_to('Download', '#', class: 'download-button button')
         %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,10 @@ Rails.application.routes.draw do
     }
   end
 
-  get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history', as: 'changes_history'
+  get 'annual_report_uploads/:id/changes_history',
+    to: 'annual_report_uploads#changes_history', as: 'changes_history'
+  get 'annual_report_uploads/:id/download_error_report',
+    to: 'annual_report_uploads#download_error_report', as: 'download_error_report'
   resources :annual_report_uploads, only: [:index, :show, :destroy] do
     resources :shipments, only: [:index, :destroy]
   end


### PR DESCRIPTION
This is about [downloading the error report](https://www.pivotaltracker.com/story/show/135121221).
It uses the already existing CitesReportValidator logic and it makes it possible to download the error report from the modal windows and the link in the validation errors page.
If no validation report exists, the download links are disabled.