### PR TITLE
Delete shipments from sandbox

### DIFF
--- a/app/assets/javascripts/components/shipment.js.coffee
+++ b/app/assets/javascripts/components/shipment.js.coffee
@@ -5,6 +5,7 @@ window.Shipment = class Shipment extends React.Component
     @state = {
       shipment: props.shipment
       rowType: props.rowType
+      annualReportUploadId: props.annualReportUploadId
       changesHistory: props.changesHistory
     }
 
@@ -44,7 +45,11 @@ window.Shipment = class Shipment extends React.Component
           div(
             {}
             a(
-              { className: 'green-link-underlined' }
+              {
+                className: 'green-link-underlined'
+                href: "/annual_report_uploads/#{@state.annualReportUploadId}/shipments/#{@state.shipment.id}"
+                "data-method": 'delete'
+              }
               i({ className: 'fa fa-times' })
               " #{I18n.t('delete')}"
             )

--- a/app/assets/javascripts/components/shipments.js.coffee
+++ b/app/assets/javascripts/components/shipments.js.coffee
@@ -7,6 +7,7 @@ window.Shipments = class Shipments extends React.Component
       pageName: props.pageName,
       page: props.page,
       annualReportUploadId: props.annualReportUploadId
+      changesHistory: props.changesHistory
     }
 
   render: ->
@@ -30,10 +31,11 @@ window.Shipments = class Shipments extends React.Component
             key: shipment.id
             shipment: shipment
             rowType: rowType
-            changesHistory: !!@state.annualReportUploadId
+            annualReportUploadId: @state.annualReportUploadId
+            changesHistory: @state.changesHistory
           }
         )
-        if @state.annualReportUploadId
+        if @state.changesHistory
           for version, v_idx in shipment.versions
             React.createElement(ShipmentVersion,
               {
@@ -49,7 +51,7 @@ window.Shipments = class Shipments extends React.Component
     props = props || @props
     url = window.location.origin
     aru_id = @state.annualReportUploadId
-    if aru_id
+    if @state.changesHistory
       url = url + "/api/v1/annual_report_uploads/#{aru_id}/changes_history"
     else
       url = url + '/api/v1/shipments'

--- a/app/assets/javascripts/components/shipments.js.coffee
+++ b/app/assets/javascripts/components/shipments.js.coffee
@@ -49,12 +49,12 @@ window.Shipments = class Shipments extends React.Component
 
   getData: (props) ->
     props = props || @props
-    url = window.location.origin
     aru_id = @state.annualReportUploadId
+    url = window.location.origin + "/api/v1/annual_report_uploads/#{aru_id}"
     if @state.changesHistory
-      url = url + "/api/v1/annual_report_uploads/#{aru_id}/changes_history"
+      url = url + "/changes_history"
     else
-      url = url + '/api/v1/shipments'
+      url = url + '/shipments'
     $.ajax({
       url: url
       data: props.pageName + "=" + props.page

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -7,6 +7,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
       totalPages: props.totalPages,
       page: 1,
       annualReportUploadId: props.annualReportUploadId
+      changesHistory: props.changesHistory
     }
     @incrementPage = @changePage.bind(@, 1)
     @decrementPage = @changePage.bind(@, -1)
@@ -27,7 +28,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
   renderHead: ->
     thead({},
       tr({},
-        if @state.annualReportUploadId
+        if @state.changesHistory
           th({}
             div({}, 'Reference')
             div({ className: 'subtitle' }, 'Change time')
@@ -61,7 +62,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
           div({}, 'Source-')
           div({}, 'Year')
         )
-        unless @state.annualReportUploadId
+        unless @state.changesHistory
           th({}, 'Actions')
       )
     )
@@ -73,6 +74,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
         pageName: @state.pageName
         page: @state.page
         annualReportUploadId: @state.annualReportUploadId
+        changesHistory: @state.changesHistory
       }
     )
 

--- a/app/assets/javascripts/components/validation_error.js.coffee
+++ b/app/assets/javascripts/components/validation_error.js.coffee
@@ -18,7 +18,7 @@ window.ValidationError = class ValidationError extends React.Component
       div(
         { className: 'error-message' }
         a(
-          { href: '/shipments/' }
+          { href: "/annual_report_uploads/#{@state.data.annual_report_upload_id}/shipments/" }
           @state.data.error_message
         )
       )

--- a/app/assets/javascripts/components/validation_errors.js.coffee
+++ b/app/assets/javascripts/components/validation_errors.js.coffee
@@ -3,11 +3,11 @@ window.ValidationErrors = class ValidationErrors extends React.Component
   constructor: (props, context) ->
     super(props, context)
     @state = {
-      data: @props.validationErrors,
+      data: props.validationErrors,
       numToShow: 5
       showAllErrors: false
       hideAll: false
-      ignored: @props.ignored
+      ignored: props.ignored
     }
     @toggleBox = @toggleBox.bind(@)
     @showMoreErrors = @showMore.bind(@)

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,6 +1,6 @@
 class AnnualReportUploadsController < ApplicationController
   before_action :authenticate_user!
-  before_action :authorise_destroy, only: [:destroy]
+  before_action :authorise_edit, only: [:destroy]
   respond_to :json
 
   def index
@@ -58,25 +58,4 @@ class AnnualReportUploadsController < ApplicationController
   def authenticate_user!
     render "unauthorised" unless (current_epix_user || current_sapi_user).present?
   end
-
-  def authorise_destroy
-    aru = Trade::AnnualReportUpload.find(params[:id])
-    creator = aru.creator
-    authorised = true
-    if creator.is_a?(Epix::User)
-      if current_user.is_a?(Sapi::User)
-        flash[:alert] = t('aru_not_deleted')
-        redirect_to annual_report_uploads_path and return true
-      end
-      authorised = (current_user.id == creator.id ||
-        (current_user.organisation.id == creator.organisation.id && current_user.is_admin))
-    else
-      authorised = current_user.is_a?(Sapi::User) && current_user.role == Sapi::User::MANAGER
-    end
-    if !authorised || aru.submitted_at.present?
-      flash[:alert] = t('aru_not_deleted')
-      redirect_to annual_report_uploads_path
-    end
-  end
-
 end

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -2,7 +2,9 @@ class Api::V1::ShipmentsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @shipments = Trade::SandboxTemplate.all.paginate(
+    @annual_report_upload =
+      Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
+    @shipments = @annual_report_upload.sandbox.shipments.paginate(
       page: params[:shipments]).map do |shipment|
         SandboxShipmentSerializer.new(shipment)
       end

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,4 +1,6 @@
 class ShipmentsController < ApplicationController
+  before_action :authorise_edit, only: [:destroy]
+
   def index
     @annual_report_upload =
       Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
@@ -11,7 +13,11 @@ class ShipmentsController < ApplicationController
     @annual_report_upload =
       Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
     @shipment = @annual_report_upload.sandbox.ar_klass.find(params[:id])
-    @shipment.destroy
+    if @shipment.destroy
+      flash[:notice] = t('shipment_deleted')
+    else
+      flash[:error] = t('shipment_not_deleted')
+    end
     redirect_to annual_report_upload_shipments_path(@annual_report_upload)
   end
 end

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,5 +1,7 @@
 class ShipmentsController < ApplicationController
   def index
+    @annual_report_upload =
+      Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
     shipments = Trade::SandboxTemplate.all
     per_page = Trade::SandboxTemplate.per_page
     @total_pages = (shipments.count / per_page.to_f).ceil

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -8,7 +8,10 @@ class ShipmentsController < ApplicationController
   end
 
   def destroy
-    @shipment = Trade::SandboxTemplate.find(params[:id])
+    @annual_report_upload =
+      Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
+    @shipment = @annual_report_upload.sandbox.ar_klass.find(params[:id])
     @shipment.destroy
+    redirect_to annual_report_upload_shipments_path(@annual_report_upload)
   end
 end

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -2,8 +2,13 @@ class ShipmentsController < ApplicationController
   def index
     @annual_report_upload =
       Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
-    shipments = Trade::SandboxTemplate.all
+    shipments = @annual_report_upload.sandbox.shipments
     per_page = Trade::SandboxTemplate.per_page
     @total_pages = (shipments.count / per_page.to_f).ceil
+  end
+
+  def destroy
+    @shipment = Trade::SandboxTemplate.find(params[:id])
+    @shipment.destroy
   end
 end

--- a/app/views/annual_report_uploads/changes_history.html.erb
+++ b/app/views/annual_report_uploads/changes_history.html.erb
@@ -18,5 +18,6 @@
       pageName: 'shipments',
       totalPages: @total_pages,
       annualReportUploadId: @annual_report_upload.id,
+      changesHistory: true
     }
 %>

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -15,6 +15,8 @@
   react_component 'ShipmentsTable',
     {
       pageName: 'shipments',
-      totalPages: @total_pages
+      totalPages: @total_pages,
+      annualReportUploadId: @annual_report_upload.id,
+      changesHistory: false
     }
 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,6 @@ en:
   unauthorised: "You are not authorised to access this resource."
   aru_deleted: 'Annual Report Upload successfully deleted.'
   aru_not_deleted: 'Cannot delete Annual Report Upload.'
+  shipment_deleted: 'Shipment successfully deleted.'
+  shipment_not_deleted: 'Cannot delete shipment.'
+  action_unauthorised: 'You are not authorised to perform this action.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,16 +20,17 @@ Rails.application.routes.draw do
 
   get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history', as: 'changes_history'
   resources :annual_report_uploads, only: [:index, :show, :destroy] do
-    resources :shipments, only: [:index]
+    resources :shipments, only: [:index, :destroy]
   end
 
   wash_out "api/v1/cites_reporting"
 
   namespace :api do
     namespace :v1 do
-      resources :annual_report_uploads, only: [:index]
       get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history'
-      resources :shipments, only: [:index]
+      resources :annual_report_uploads, only: [:index] do
+        resources :shipments, only: [:index]
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,10 @@ Rails.application.routes.draw do
     }
   end
 
-  resources :annual_report_uploads, only: [:index, :show, :destroy]
   get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history', as: 'changes_history'
-  resources :shipments, only: [:index]
+  resources :annual_report_uploads, only: [:index, :show, :destroy] do
+    resources :shipments, only: [:index]
+  end
 
   wash_out "api/v1/cites_reporting"
 

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -140,6 +140,9 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
   end
 
   describe "DELETE destroy" do
+    before(:each) do
+      request.env['HTTP_REFERER'] = 'http://example.com'
+    end
     context "when current user is admin from SAPI" do
       before(:each) do
         @epix_user = FactoryGirl.create(:epix_user)

--- a/spec/controllers/api/v1/shipments_controller_spec.rb
+++ b/spec/controllers/api/v1/shipments_controller_spec.rb
@@ -4,13 +4,35 @@ RSpec.describe Api::V1::ShipmentsController, type: :controller do
   describe "GET index" do
     before(:each) do
       @epix_user = FactoryGirl.create(:epix_user)
-      @shipment = FactoryGirl.create(:sandbox_template)
+      @aru = FactoryGirl.create(:annual_report_upload)
+      @aru.sandbox.copy_data({
+        CITESReport: [
+          {
+            CITESReportRow:  {
+              TradingPartnerId:  "FR",
+              Year:  2016,
+              ScientificName:  "Alligator mississipiensis",
+              Appendix:  nil,
+              TermCode:  "SKI",
+              Quantity:  5.0,
+              UnitCode:  "KIL",
+              SourceCode:  "W",
+              PurposeCode:  "Z",
+              OriginCountryId:  "US",
+              OriginPermitId:  nil,
+              ExportPermitId:  "CH123",
+              ImportPermitId:  nil
+            }
+          }
+        ]
+      })
+      @shipment = @aru.sandbox.ar_klass.first
     end
 
     it "should assign shipments" do
       @request.env['devise.mapping'] = Devise.mappings[:epix_user]
       sign_in @epix_user
-      get :index
+      get :index, annual_report_upload_id: @aru
 
       expect(assigns(:shipments).size).to eq(1)
     end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe ShipmentsController, type: :controller do
   describe "GET index" do
     before(:each) do
       @epix_user = FactoryGirl.create(:epix_user)
+      @aru = FactoryGirl.create(:annual_report_upload)
       @shipment = FactoryGirl.create(:sandbox_template)
     end
 
     it "should assigns total number of pages" do
       @request.env['devise.mapping'] = Devise.mappings[:epix_user]
       sign_in @epix_user
-      get :index
+      get :index, annual_report_upload_id: @aru
 
       expect(assigns(:total_pages)).to eq(1)
     end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -1,31 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe ShipmentsController, type: :controller do
+  CITES_REPORT = {
+    CITESReport: [
+      {
+        CITESReportRow:  {
+          TradingPartnerId:  "FR",
+          Year:  2016,
+          ScientificName:  "Alligator mississipiensis",
+          Appendix:  nil,
+          TermCode:  "SKI",
+          Quantity:  5.0,
+          UnitCode:  "KIL",
+          SourceCode:  "W",
+          PurposeCode:  "Z",
+          OriginCountryId:  "US",
+          OriginPermitId:  nil,
+          ExportPermitId:  "CH123",
+          ImportPermitId:  nil
+        }
+      }
+    ]
+  }
   describe "GET index" do
     before(:each) do
       @epix_user = FactoryGirl.create(:epix_user)
       @aru = FactoryGirl.create(:annual_report_upload)
-      @aru.sandbox.copy_data({
-        CITESReport: [
-          {
-            CITESReportRow:  {
-              TradingPartnerId:  "FR",
-              Year:  2016,
-              ScientificName:  "Alligator mississipiensis",
-              Appendix:  nil,
-              TermCode:  "SKI",
-              Quantity:  5.0,
-              UnitCode:  "KIL",
-              SourceCode:  "W",
-              PurposeCode:  "Z",
-              OriginCountryId:  "US",
-              OriginPermitId:  nil,
-              ExportPermitId:  "CH123",
-              ImportPermitId:  nil
-            }
-          }
-        ]
-      })
+      @aru.sandbox.copy_data(CITES_REPORT)
       @shipment = @aru.sandbox.ar_klass.first
     end
 
@@ -37,4 +38,147 @@ RSpec.describe ShipmentsController, type: :controller do
       expect(assigns(:total_pages)).to eq(1)
     end
   end
+
+  describe "DELETE destroy" do
+    before(:each) do
+      request.env['HTTP_REFERER'] = 'http://example.com'
+    end
+    context "when current user is admin from SAPI" do
+      before(:each) do
+        @epix_user = FactoryGirl.create(:epix_user)
+        @sapi_user = FactoryGirl.create(:sapi_user)
+        @request.env['devise.mapping'] = Devise.mappings[:sapi_user]
+        sign_in @sapi_user
+      end
+      context "when aru created by another SAPI user" do
+        before(:each) do
+          @another_sapi_user = FactoryGirl.create(:sapi_user)
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            created_by_id: @another_sapi_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(-1)
+        end
+      end
+      context "when aru created by EPIX user" do
+        before(:each) do
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should not destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(0)
+        end
+      end
+    end
+    context "when current user is admin from EPIX" do
+      before(:each) do
+        @epix_user = FactoryGirl.create(:epix_user, is_admin: true)
+        @sapi_user = FactoryGirl.create(:sapi_user)
+        @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+        sign_in @epix_user
+      end
+      context "when aru created by EPIX user from same organisation" do
+        before(:each) do
+          @organisation = @epix_user.organisation
+          @another_epix_user = FactoryGirl.create(:epix_user, organisation: @organisation)
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @another_epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(-1)
+        end
+      end
+      context "when aru created by EPIX user from another organisation" do
+        before(:each) do
+          @another_epix_user = FactoryGirl.create(:epix_user)
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @another_epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(0)
+        end
+      end
+    end
+    context "when current user is not an admin from EPIX" do
+      before(:each) do
+        @epix_user = FactoryGirl.create(:epix_user, is_admin: false)
+        @sapi_user = FactoryGirl.create(:sapi_user)
+        @request.env['devise.mapping'] = Devise.mappings[:epix_user]
+        sign_in @epix_user
+      end
+      context "when aru created by the same EPIX user" do
+        before(:each) do
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(-1)
+        end
+      end
+      context "when aru created by EPIX user from same organisation" do
+        before(:each) do
+          @organisation = @epix_user.organisation
+          @another_epix_user = FactoryGirl.create(:epix_user, organisation: @organisation)
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @another_epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(0)
+        end
+      end
+      context "when aru created by EPIX user from another organisation" do
+        before(:each) do
+          @another_epix_user = FactoryGirl.create(:epix_user)
+          @aru = FactoryGirl.create(
+            :annual_report_upload,
+            epix_created_by_id: @another_epix_user.id
+          )
+          @aru.sandbox.copy_data(CITES_REPORT)
+          @shipment = @aru.sandbox.ar_klass.first
+        end
+        it "should destroy shipment" do
+          expect {
+            delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          }.to change(@aru.sandbox.ar_klass, :count).by(0)
+        end
+      end
+    end
+  end
+
 end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -5,7 +5,28 @@ RSpec.describe ShipmentsController, type: :controller do
     before(:each) do
       @epix_user = FactoryGirl.create(:epix_user)
       @aru = FactoryGirl.create(:annual_report_upload)
-      @shipment = FactoryGirl.create(:sandbox_template)
+      @aru.sandbox.copy_data({
+        CITESReport: [
+          {
+            CITESReportRow:  {
+              TradingPartnerId:  "FR",
+              Year:  2016,
+              ScientificName:  "Alligator mississipiensis",
+              Appendix:  nil,
+              TermCode:  "SKI",
+              Quantity:  5.0,
+              UnitCode:  "KIL",
+              SourceCode:  "W",
+              PurposeCode:  "Z",
+              OriginCountryId:  "US",
+              OriginPermitId:  nil,
+              ExportPermitId:  "CH123",
+              ImportPermitId:  nil
+            }
+          }
+        ]
+      })
+      @shipment = @aru.sandbox.ar_klass.first
     end
 
     it "should assigns total number of pages" do


### PR DESCRIPTION
This is about [Authorised user can delete shipments from a sandbox](https://www.pivotaltracker.com/story/show/135324625).
To make this work properly, the shipments resources have been nested inside the annual_report_uploads ones, so it's possible to get the shipments based on the aru.
The authorisation for destroying a shipments follows the same logic as the aru, so that logic has been generalised and can be used for managing both aru and shipments.
At the moment I have only considered the deletion of the shipments itself, without wondering about empty sandboxes; not sure whether when the last shipment is deleted, than the sandbox and the aru get deleted as well.