### PR TITLE
Fix whodunnit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_locale
+  before_action :set_paper_trail_whodunnit
   helper_method :current_user, :destroy_user
 
   def after_sign_in_path_for(resource)
@@ -64,5 +65,9 @@ class ApplicationController < ActionController::Base
       flash[:alert] = t('action_unauthorised')
       redirect_to (request.referer || root_path)
     end
+  end
+
+  def user_for_paper_trail
+    current_user.is_a?(Epix::User) ? "Epix:#{current_user.id}" : "Sapi:#{current_user.id}"
   end
 end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -169,6 +169,10 @@ RSpec.describe ShipmentsController, type: :controller do
           expect(CitesReportValidationJob).to(receive(:perform_later).with(@aru.id, false))
           delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
         end
+        it "should set whodunnit correctly", versioning: true do
+          delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          expect(PaperTrail::Version.last.whodunnit).to eq("Sapi:#{@sapi_user.id}")
+        end
       end
       context "when aru created by EPIX user" do
         before(:each) do
@@ -213,6 +217,10 @@ RSpec.describe ShipmentsController, type: :controller do
           expect(CitesReportValidationJob).to(receive(:perform_later).with(@aru.id, false))
           delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
         end
+        it "should set whodunnit correctly", versioning: true do
+          delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          expect(PaperTrail::Version.last.whodunnit).to eq("Epix:#{@epix_user.id}")
+        end
       end
       context "when aru created by EPIX user from another organisation" do
         before(:each) do
@@ -255,6 +263,10 @@ RSpec.describe ShipmentsController, type: :controller do
         it "should run validation job" do
           expect(CitesReportValidationJob).to(receive(:perform_later).with(@aru.id, false))
           delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+        end
+        it "should set whodunnit correctly", versioning: true do
+          delete :destroy, { annual_report_upload_id: @aru.id, id: @shipment.id }
+          expect(PaperTrail::Version.last.whodunnit).to eq("Epix:#{@epix_user.id}")
         end
       end
       context "when aru created by EPIX user from same organisation" do


### PR DESCRIPTION
This automatically sets the `whodunnit` field in `PaperTrail::Version` when a change happens to shipments.
I ended up just amending the string that gets used to set the field mainly because, changing the whodunnit field to jsonb was causing troubles and also might end up causing incompatibility issues to the TaxonConcept versioning since we also use PaperTrail with the TaxonConcept model.
So the string gets set like this:
  if current_user is from SAPI: "Sapi:user_id"
  else: "Epix:user_id"