### PR TITLE
Get only shipments affected by error

### DIFF
--- a/app/assets/javascripts/components/shipments.js.coffee
+++ b/app/assets/javascripts/components/shipments.js.coffee
@@ -7,6 +7,7 @@ window.Shipments = class Shipments extends React.Component
       pageName: props.pageName,
       page: props.page,
       annualReportUploadId: props.annualReportUploadId
+      validationErrorId: props.validationErrorId
       changesHistory: props.changesHistory
     }
 
@@ -50,11 +51,15 @@ window.Shipments = class Shipments extends React.Component
   getData: (props) ->
     props = props || @props
     aru_id = @state.annualReportUploadId
+    validation_error_id = @state.validationErrorId
     url = window.location.origin + "/api/v1/annual_report_uploads/#{aru_id}"
     if @state.changesHistory
       url = url + "/changes_history"
     else
-      url = url + '/shipments'
+      if validation_error_id
+        url = url + "/validation_errors/#{validation_error_id}/shipments"
+      else
+        url = url + '/shipments'
     $.ajax({
       url: url
       data: props.pageName + "=" + props.page

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -7,6 +7,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
       totalPages: props.totalPages,
       page: 1,
       annualReportUploadId: props.annualReportUploadId
+      validationErrorId: props.validationErrorId
       changesHistory: props.changesHistory
     }
     @incrementPage = @changePage.bind(@, 1)
@@ -74,6 +75,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
         pageName: @state.pageName
         page: @state.page
         annualReportUploadId: @state.annualReportUploadId
+        validationErrorId: @state.validationErrorId
         changesHistory: @state.changesHistory
       }
     )

--- a/app/assets/javascripts/components/validation_error.js.coffee
+++ b/app/assets/javascripts/components/validation_error.js.coffee
@@ -9,6 +9,7 @@ window.ValidationError = class ValidationError extends React.Component
     @ignoreValidationError = @ignoreError.bind(@)
 
   render: ->
+    base_url = "/annual_report_uploads/#{@state.data.annual_report_upload_id}"
     div(
       { className: 'validation-error' }
       div(
@@ -18,7 +19,7 @@ window.ValidationError = class ValidationError extends React.Component
       div(
         { className: 'error-message' }
         a(
-          { href: "/annual_report_uploads/#{@state.data.annual_report_upload_id}/shipments/" }
+          { href: base_url + "/validation_errors/#{@state.data.id}/shipments" }
           @state.data.error_message
         )
       )

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -4,7 +4,8 @@ class Api::V1::ShipmentsController < ApplicationController
   def index
     @annual_report_upload =
       Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
-    @shipments = @annual_report_upload.sandbox.shipments.paginate(
+    @validation_error = Trade::ValidationError.find_by_id(params[:validation_error_id])
+    @shipments = @annual_report_upload.sandbox.shipments(@validation_error).paginate(
       page: params[:shipments]).map do |shipment|
         SandboxShipmentSerializer.new(shipment)
       end

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -4,7 +4,8 @@ class ShipmentsController < ApplicationController
   def index
     @annual_report_upload =
       Trade::AnnualReportUpload.find(params[:annual_report_upload_id])
-    shipments = @annual_report_upload.sandbox.shipments
+    @validation_error = Trade::ValidationError.find_by_id(params[:validation_error_id])
+    shipments = @annual_report_upload.sandbox.shipments(@validation_error)
     per_page = Trade::SandboxTemplate.per_page
     @total_pages = (shipments.count / per_page.to_f).ceil
   end

--- a/app/models/trade/sandbox.rb
+++ b/app/models/trade/sandbox.rb
@@ -68,8 +68,14 @@ class Trade::Sandbox
     )
   end
 
-  def shipments
-    @ar_klass.order(:id).all
+  def shipments(validation_error=nil)
+    if validation_error
+      validation_error.validation_rule.
+        matching_records_for_aru_and_error(@annual_report_upload, validation_error).
+        order(:id)
+    else
+      @ar_klass.order(:id).all
+    end
   end
 
   def shipments=(new_shipments)

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -17,6 +17,7 @@
       pageName: 'shipments',
       totalPages: @total_pages,
       annualReportUploadId: @annual_report_upload.id,
+      validationErrorId: @validation_error.id,
       changesHistory: false
     }
 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     to: 'annual_report_uploads#download_error_report', as: 'download_error_report'
   resources :annual_report_uploads, only: [:index, :show, :destroy] do
     resources :shipments, only: [:index, :destroy]
+    get 'validation_errors/:validation_error_id/shipments', to: 'shipments#index', as: 'shipment_with_errors'
   end
 
   wash_out "api/v1/cites_reporting"
@@ -33,6 +34,7 @@ Rails.application.routes.draw do
       get 'annual_report_uploads/:id/changes_history', to: 'annual_report_uploads#changes_history'
       resources :annual_report_uploads, only: [:index] do
         resources :shipments, only: [:index]
+        get 'validation_errors/:validation_error_id/shipments', to: 'shipments#index', as: 'shipment_with_errors'
       end
     end
   end


### PR DESCRIPTION
[When viewing shipments by clicking on an error link, only shipments affected by that error should be displayed](https://www.pivotaltracker.com/story/show/135502707)

I've added a new route for the index action in shipments so to include the validation error the id and filter the shipments by that if it is present.