### PR TITLE
Fix nil exception in whodunnit

### DIFF
--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,5 +1,4 @@
 class AnnualReportUploadsController < ApplicationController
-  before_action :authenticate_user!
   before_action :authorise_edit, only: [:destroy]
   respond_to :json
 
@@ -61,9 +60,4 @@ class AnnualReportUploadsController < ApplicationController
     send_data data, type: 'text/csv', filename: "validation_report_#{aru.id}.csv"
   end
 
-  private
-
-  def authenticate_user!
-    render "unauthorised" unless (current_epix_user || current_sapi_user).present?
-  end
 end

--- a/app/controllers/api/v1/annual_report_uploads_controller.rb
+++ b/app/controllers/api/v1/annual_report_uploads_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::AnnualReportUploadsController < ApplicationController
-  before_action :authenticate_user!
 
   def index
     epix_user_id = current_epix_user && current_epix_user.id
@@ -40,9 +39,4 @@ class Api::V1::AnnualReportUploadsController < ApplicationController
     }
   end
 
-  private
-
-  def authenticate_user!
-    render "unauthorised" unless (current_epix_user || current_sapi_user).present?
-  end
 end

--- a/app/controllers/api/v1/cites_reporting_controller.rb
+++ b/app/controllers/api/v1/cites_reporting_controller.rb
@@ -1,11 +1,11 @@
-class Api::V1::CitesReportingController < ApplicationController
+class Api::V1::CitesReportingController < ActionController::Base
+  protect_from_forgery with: :null_session
   soap_service namespace: 'urn:CitesReporting/v1/', wsse_auth_callback: -> (email, password) {
     user = Epix::User.includes(:organisation).
       where(email: email, 'organisations.role' => Epix::Organisation::CITES_MA).
       first
     return user.present? && user.valid_password?(password)
   }
-
   before_action :load_user_and_organisation, except: :_generate_wsdl
 
   rescue_from NoMethodError, with: :handle_no_method_error

--- a/app/controllers/api/v1/cites_reporting_controller.rb
+++ b/app/controllers/api/v1/cites_reporting_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::CitesReportingController < ActionController::Base
 
   def log_error(exception)
     if Rails.env.production? || Rails.env.staging?
-      # TODO: Appsignal.add_exception(exception) if defined? Appsignal
+      Appsignal.add_exception(exception) if defined? Appsignal
     else
       Rails.logger.error exception.message
       Rails.logger.error exception.backtrace.join("\n")

--- a/app/controllers/api/v1/shipments_controller.rb
+++ b/app/controllers/api/v1/shipments_controller.rb
@@ -1,5 +1,4 @@
 class Api::V1::ShipmentsController < ApplicationController
-  before_action :authenticate_user!
 
   def index
     @annual_report_upload =
@@ -15,9 +14,4 @@ class Api::V1::ShipmentsController < ApplicationController
     }
   end
 
-  private
-
-  def authenticate_user!
-    render "unauthorised" unless (current_epix_user || current_sapi_user).present?
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_locale
+  before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
   helper_method :current_user, :destroy_user
 
@@ -44,6 +45,10 @@ class ApplicationController < ActionController::Base
     I18n.locale = params[:locale] || I18n.default_locale
   end
 
+  def authenticate_user!
+    render "annual_report_uploads/unauthorised" unless (current_epix_user || current_sapi_user).present?
+  end
+
   def authorise_edit
     aru_id = params[:annual_report_upload_id] || params[:id]
     aru = Trade::AnnualReportUpload.find(aru_id)
@@ -65,6 +70,10 @@ class ApplicationController < ActionController::Base
       flash[:alert] = t('action_unauthorised')
       redirect_to (request.referer || root_path)
     end
+  end
+
+  def paper_trail_enabled_for_controller
+    !(is_a? ::Devise::SessionsController)
   end
 
   def user_for_paper_trail

--- a/app/controllers/epix_user/sessions_controller.rb
+++ b/app/controllers/epix_user/sessions_controller.rb
@@ -1,5 +1,5 @@
 class EpixUser::SessionsController < Devise::SessionsController
- before_action :is_authorised?, only: [:create]
+  before_action :is_authorised?, only: [:create]
 
   def new
     @email = params[:user]

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -277,3 +277,7 @@ Devise.setup do |config|
 
 
 end
+
+Rails.application.config.to_prepare do
+  Devise::SessionsController.skip_before_filter :authenticate_user!
+end


### PR DESCRIPTION
The issue was caused by the fact that `set_paper_trail_whodunnit` was called in situations where `authenticate_user!` was not previously called. The two need to always go together, and the best way is to define both `before_action` filters in `ApplicationController`. We have some controllers which should be excluded from either: the session controllers, and the SOAP controller. The soap controller is better off not inheriting from ApplicationController, as it is quite a different controller altogether. The session controllers are excluded from `authenticate_user!` using `skip_before_action`, but unfortunately the same method does not work for `set_paper_trail_whodunnit` - to disable that, you need to disable PaperTrail for a controller, which is done by overriding the `paper_trail_enabled_for_controller` method.