### PR TITLE
Amend design for changes

### DIFF
--- a/app/assets/javascripts/components/shipment.js.coffee
+++ b/app/assets/javascripts/components/shipment.js.coffee
@@ -34,7 +34,13 @@ window.Shipment = class Shipment extends React.Component
       td({}
         data.purpose_code + ' - ' + data.source_code + ' - ' + data.year
       )
-      unless @state.changesHistory
+      if @state.changesHistory
+        [
+          td({}, '')
+          td({}, '')
+        ]
+      else
+        @state.changesHistory
         td({ className: 'actions-col' },
           div(
             {}

--- a/app/assets/javascripts/components/shipment.js.coffee
+++ b/app/assets/javascripts/components/shipment.js.coffee
@@ -34,13 +34,7 @@ window.Shipment = class Shipment extends React.Component
       td({}
         data.purpose_code + ' - ' + data.source_code + ' - ' + data.year
       )
-      if @state.changesHistory
-        [
-          td({}, '')
-          td({}, '')
-        ]
-      else
-        @state.changesHistory
+      unless @state.changesHistory
         td({ className: 'actions-col' },
           div(
             {}

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -23,7 +23,7 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
     tr({ className: @state.rowType },
       td({}
         div({ className: "bold" }, data.updated_at)
-        div({ className: "italic" }, changes)
+        div({ className: "italic" }, changes + " by " + @getEditor())
       )
       td({}, span({ className: "appendix" }, data.appendix))
       td({},
@@ -47,17 +47,13 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
         " - "
         span({ className: "#{@state.index}_year" }, + data.year)
       )
-      td({}, span({ className: "#{@state.index}_updated_at"}, data.updated_at))
-      @showEditor()
     )
 
-  showEditor: ->
-    editor = ''
+  getEditor: ->
     if @state.userType == 'sapi' || (@state.userType == @state.shipment.editor)
-      editor = @state.shipment.updated_by
+      @state.shipment.whodunnit
     else
-      editor = 'WCMC'
-    td({}, span({ className: "#{@state.index}_updated_by"}, editor))
+      'WCMC'
 
 
 

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -7,6 +7,7 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
       index: props.index
       changes: props.changes
       rowType: props.rowType
+      userType: props.userType
     }
 
   render: ->
@@ -47,8 +48,18 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
         span({ className: "#{@state.index}_year" }, + data.year)
       )
       td({}, span({ className: "#{@state.index}_updated_at"}, data.updated_at))
-      td({}, span({ className: "#{@state.index}_updated_by"}, data.updated_by))
+      @showEditor()
     )
+
+  showEditor: ->
+    editor = ''
+    if @state.userType == 'sapi' || (@state.userType == @state.shipment.editor)
+      editor = @state.shipment.updated_by
+    else
+      editor = 'WCMC'
+    td({}, span({ className: "#{@state.index}_updated_by"}, editor))
+
+
 
   componentDidMount: ->
     keys = Object.keys(@state.changes)

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -11,11 +11,17 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
   render: ->
     data = @state.shipment
     keys = Object.keys(@state.changes)
-    changes = if keys.length > 1 then ' changes' else ' change'
+    changes = ''
+    if keys.length == 0
+      changes = 'deleted'
+    else if keys.length > 1
+      changes = "#{keys.length} changes"
+    else
+      changes = "1 change"
     tr({ className: @state.rowType },
       td({}
         div({ className: 'bold' }, data.updated_at)
-        div({ className: 'italic' }, keys.length + changes)
+        div({ className: 'italic' }, changes)
       )
       td({}, span({ className: 'appendix' }, data.appendix))
       td({},
@@ -39,6 +45,8 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
         ' - '
         span({ className: 'year' }, + data.year)
       )
+      td({}, span({ className: 'updated_at'}, data.updated_at))
+      td({}, span({ className: 'updated_by'}, data.updated_by))
     )
 
   componentDidMount: ->

--- a/app/assets/javascripts/components/shipment_version.js.coffee
+++ b/app/assets/javascripts/components/shipment_version.js.coffee
@@ -4,6 +4,7 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
     super(props, context)
     @state = {
       shipment: props.shipment
+      index: props.index
       changes: props.changes
       rowType: props.rowType
     }
@@ -20,39 +21,39 @@ window.ShipmentVersion = class ShipmentVersion extends React.Component
       changes = "1 change"
     tr({ className: @state.rowType },
       td({}
-        div({ className: 'bold' }, data.updated_at)
-        div({ className: 'italic' }, changes)
+        div({ className: "bold" }, data.updated_at)
+        div({ className: "italic" }, changes)
       )
-      td({}, span({ className: 'appendix' }, data.appendix))
+      td({}, span({ className: "appendix" }, data.appendix))
       td({},
         div(
-          { className: 'taxon_name bold' }
+          { className: "#{@state.index}_taxon_name bold" }
           data.taxon_name
         )
-        div({ className: 'accepted-name' }, data.taxon_name) # Replace with accepted_name
+        div({ className: "#{@state.index}_accepted_name" }, data.taxon_name) # Replace with accepted_name
       )
-      td({}, span({ className: 'term' }, data.term))
-      td({}, span({ className: 'quantity' }, data.quantity))
-      td({}, span({ className: 'trading_partner' }, data.trading_partner))
-      td({}, span({ className: 'country_of_origin' }, data.country_of_origin))
-      td({}, span({ className: 'import_permit' }, data.import_permit))
-      td({}, span({ className: 'export_permit' }, data.export_permit))
-      td({}, span({ className: 'origin_permit' }, data.origin_permit))
+      td({}, span({ className: "#{@state.index}_term" }, data.term))
+      td({}, span({ className: "#{@state.index}_quantity" }, data.quantity))
+      td({}, span({ className: "#{@state.index}_trading_partner" }, data.trading_partner))
+      td({}, span({ className: "#{@state.index}_country_of_origin" }, data.country_of_origin))
+      td({}, span({ className: "#{@state.index}_import_permit" }, data.import_permit))
+      td({}, span({ className: "#{@state.index}_export_permit" }, data.export_permit))
+      td({}, span({ className: "#{@state.index}_origin_permit" }, data.origin_permit))
       td({}
-        span({ className: 'purpose_code'}, data.purpose_code)
-        ' - '
-        span({ className: 'source_code' }, data.source_code)
-        ' - '
-        span({ className: 'year' }, + data.year)
+        span({ className: "#{@state.index}_purpose_code"}, data.purpose_code)
+        " - "
+        span({ className: "#{@state.index}_source_code" }, data.source_code)
+        " - "
+        span({ className: "#{@state.index}_year" }, + data.year)
       )
-      td({}, span({ className: 'updated_at'}, data.updated_at))
-      td({}, span({ className: 'updated_by'}, data.updated_by))
+      td({}, span({ className: "#{@state.index}_updated_at"}, data.updated_at))
+      td({}, span({ className: "#{@state.index}_updated_by"}, data.updated_by))
     )
 
   componentDidMount: ->
     keys = Object.keys(@state.changes)
     for key in keys
-      regex = new RegExp(".*#{key}.*")
+      regex = new RegExp(".*#{@state.index}_#{key}.*")
       $('td span').filter( ->
         if $(@).attr('class') && $(@).attr('class').match(regex)
           $(@).addClass('changed')

--- a/app/assets/javascripts/components/shipments.js.coffee
+++ b/app/assets/javascripts/components/shipments.js.coffee
@@ -10,6 +10,7 @@ window.Shipments = class Shipments extends React.Component
       validationErrorId: props.validationErrorId
       changesHistory: props.changesHistory
       format: props.format
+      userType: props.userType
     }
 
   render: ->
@@ -46,6 +47,7 @@ window.Shipments = class Shipments extends React.Component
                 index: v_idx
                 changes: shipment.changes[v_idx]
                 rowType: rowType
+                userType: @state.userType
               }
             )
       ]

--- a/app/assets/javascripts/components/shipments.js.coffee
+++ b/app/assets/javascripts/components/shipments.js.coffee
@@ -43,6 +43,7 @@ window.Shipments = class Shipments extends React.Component
               {
                 key: "#{shipment.id}_#{v_idx}"
                 shipment: version
+                index: v_idx
                 changes: shipment.changes[v_idx]
                 rowType: rowType
               }

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -67,11 +67,6 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
         )
         unless @state.changesHistory
           th({}, 'Actions')
-        else
-          [
-            th({}, 'Updated at')
-            th({}, 'Updated by')
-          ]
       )
     )
 

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -66,6 +66,11 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
         )
         unless @state.changesHistory
           th({}, 'Actions')
+        else
+          [
+            th({}, 'Updated at')
+            th({}, 'Updated by')
+          ]
       )
     )
 

--- a/app/assets/javascripts/components/shipments_table.js.coffee
+++ b/app/assets/javascripts/components/shipments_table.js.coffee
@@ -10,6 +10,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
       validationErrorId: props.validationErrorId
       changesHistory: props.changesHistory
       format: props.format
+      userType: props.userType
     }
     @incrementPage = @changePage.bind(@, 1)
     @decrementPage = @changePage.bind(@, -1)
@@ -84,6 +85,7 @@ window.ShipmentsTable = class ShipmentsTable extends React.Component
         validationErrorId: @state.validationErrorId
         changesHistory: @state.changesHistory
         format: @state.format
+        userType: @state.userType
       }
     )
 

--- a/app/controllers/api/v1/annual_report_uploads_controller.rb
+++ b/app/controllers/api/v1/annual_report_uploads_controller.rb
@@ -34,6 +34,10 @@ class Api::V1::AnnualReportUploadsController < ApplicationController
         SandboxShipmentChangesSerializer.new(shipment)
       end
 
+    ar_klass.destroyed.map(&:reify).map do |shipment|
+      @shipments << SandboxShipmentChangesSerializer.new(shipment)
+    end
+
     render json: {
       shipments: @shipments
     }

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -22,8 +22,8 @@ class Trade::AnnualReportUpload < Sapi::Base
     foreign_key: :submitted_by_id, optional: true
 
   scope :created_by, -> (user_id) { where(epix_created_by_id: user_id) if user_id }
-  scope :submitted, -> { where("submitted_at IS NOT NULL") }
-  scope :in_progress, -> { where("submitted_at IS NULL") }
+  scope :submitted, -> { where("submitted_at IS NOT NULL OR epix_submitted_at IS NOT NULL") }
+  scope :in_progress, -> { where("submitted_at IS NULL AND epix_submitted_at IS NULL") }
 
   validates :trading_country_id, :epix_created_by_id, :epix_created_at,
     :epix_updated_by_id, :epix_updated_at, presence: true

--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -27,6 +27,15 @@ class Trade::SandboxTemplate < Sapi::Base
         has_paper_trail
         # belongs_to :taxon_concept
         # belongs_to :reported_taxon_concept, :class_name => TaxonConcept
+        belongs_to :epix_creator, class_name: Epix::User,
+          foreign_key: :epix_created_by_id, optional: true
+        belongs_to :sapi_creator, class_name: Sapi::User,
+          foreign_key: :created_by_id, optional: true
+        belongs_to :epix_updater, class_name: Epix::User,
+          foreign_key: :epix_updated_by_id, optional: true
+        belongs_to :sapi_updater, class_name: Sapi::User,
+          foreign_key: :updated_by_id, optional: true
+
 
         scope :destroyed, -> {
           PaperTrail::Version.where(event: 'destroy', item_type: self).

--- a/app/models/trade/sandbox_template.rb
+++ b/app/models/trade/sandbox_template.rb
@@ -28,6 +28,12 @@ class Trade::SandboxTemplate < Sapi::Base
         # belongs_to :taxon_concept
         # belongs_to :reported_taxon_concept, :class_name => TaxonConcept
 
+        scope :destroyed, -> {
+          PaperTrail::Version.where(event: 'destroy', item_type: self).
+          joins("LEFT JOIN #{self.table_name} ON item_id=#{self.table_name}.id").
+          where("#{self.table_name}.id IS NULL")
+        }
+
         def sanitize
           self.class.sanitize(self.id)
         end

--- a/app/serializers/annual_report_upload_serializer.rb
+++ b/app/serializers/annual_report_upload_serializer.rb
@@ -19,7 +19,13 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
   end
 
   def updated_at
-    object.updated_at.strftime("%d/%m/%y")
+    if object.epix_created_at
+      object.epix_updated_at.strftime("%d/%m/%y")
+    elsif object.updated_at
+      object.updated_at.strftime("%d/%m/%y")
+    else
+      nil
+    end
   end
 
   def created_by

--- a/app/serializers/sandbox_shipment_changes_serializer.rb
+++ b/app/serializers/sandbox_shipment_changes_serializer.rb
@@ -2,7 +2,7 @@ class SandboxShipmentChangesSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit, :versions, :changes, :updated_at
+    :year, :import_permit, :versions, :changes, :updated_at, :updated_by
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -21,12 +21,32 @@ class SandboxShipmentChangesSerializer < ActiveModel::Serializer
 
   def changes
     object.versions.map(&:changeset).each do |changes|
-      changes.delete("updated_at") if changes.present?
+      if changes.present?
+        changes.each do |key, value|
+          if key == "updated_at" || value == [nil, ""]
+            changes.delete(key)
+          end
+        end
+      end
     end
   end
 
   def updated_at
-    object.updated_at.strftime("%d/%m/%y")
+    if object.epix_updater
+      object.epix_updated_at && object.epix_updated_at.strftime("%d/%m/%y")
+    else
+      object.updated_at && object.updated_at.strftime("%d/%m/%y")
+    end
+  end
+
+  def updated_by
+    if object.epix_updater
+      object.epix_updater.name
+    elsif object.sapi_updater
+      object.sapi_updater.name
+    else
+      nil
+    end
   end
 
 end

--- a/app/serializers/sandbox_shipment_serializer.rb
+++ b/app/serializers/sandbox_shipment_serializer.rb
@@ -14,7 +14,23 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
 #  end
   #
   def updated_at
-    object.updated_at.strftime("%d/%m/%y")
+    if object.epix_updater
+      object.epix_updated_at && object.epix_updated_at.strftime("%d/%m/%y")
+    elsif object.sapi_updater
+      object.updated_at && object.updated_at.strftime("%d/%m/%y")
+    else
+      nil
+    end
+  end
+
+  def updated_by
+    if object.epix_updater
+      object.epix_updater.name
+    elsif object.sapi_updater
+      object.sapi_updater.name
+    else
+      nil
+    end
   end
 
 end

--- a/app/serializers/sandbox_shipment_serializer.rb
+++ b/app/serializers/sandbox_shipment_serializer.rb
@@ -2,7 +2,7 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
   attributes :id, :appendix, :taxon_name, #:reported_taxon_name, :accepted_taxon_name,
     :term_code, :quantity, :unit_code, :trading_partner, :country_of_origin,
     :export_permit, :origin_permit, :purpose_code, :source_code,
-    :year, :import_permit, :updated_at
+    :year, :import_permit, :updated_at, :updated_by, :editor
 
 #  def reported_taxon_name
 #    object.reported_taxon_concept && "#{object.reported_taxon_concept.full_name} (#{object.reported_taxon_concept.name_status})" ||
@@ -31,6 +31,10 @@ class SandboxShipmentSerializer < ActiveModel::Serializer
     else
       nil
     end
+  end
+
+  def editor
+    object.epix_updater ? 'epix' : 'sapi'
   end
 
 end

--- a/app/serializers/show_annual_report_upload_serializer.rb
+++ b/app/serializers/show_annual_report_upload_serializer.rb
@@ -35,7 +35,13 @@ class ShowAnnualReportUploadSerializer < ActiveModel::Serializer
   end
 
   def updated_at
-    object.updated_at.strftime("%d/%m/%y")
+    if object.epix_updater
+      object.epix_updated_at && object.epix_updated_at.strftime("%d/%m/%y")
+    elsif object.sapi_updater
+      object.updated_at && object.updated_at.strftime("%d/%m/%y")
+    else
+      nil
+    end
   end
 
   def created_by

--- a/app/views/shared/_shipments_table.html.erb
+++ b/app/views/shared/_shipments_table.html.erb
@@ -5,6 +5,7 @@
       totalPages: @total_pages,
       annualReportUploadId: @annual_report_upload.id,
       changesHistory: changesHistory,
-      format: format
+      format: format,
+      userType: current_epix_user ? 'epix' : current_sapi_user ? 'sapi' : ''
     }
 %>


### PR DESCRIPTION
This is mainly about [display who and when changes have been made to shipments in history page](https://www.pivotaltracker.com/story/show/133836795).
It also includes some amendments such as various updates on the serializers to accomodate the multiple created and updated fields, updates on the shipments class to include relationships with users, inclusion of destroyed shipments in the table and fixes on the correct display of the changed fields.