### PR TITLE
Populate shipments form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,13 @@ MAILER_PASSWORD=xxxxxxxxxx
 MAILER_HOST=xxxxxxxxxx
 MAILER_FROM=no-reply@unep-wcmc.org
 
+HOST=xxxxxxxxxx
+
 EPIX_URL=https://epix-staging.linode.unep-wcmc.org/
+EPIX_STAGING_PATH=xxxxxxxxxx
+EPIX_PRODUCTION_PATH=xxxxxxxxxx
+
 TRADE_ADMIN_URL=https://sapi.sapi-staging.linode.unep-wcmc.org/trade
+SAPI_STAGING_PATH=xxxxxxxxxx
+SAPI_PRODUCTION_PATH=xxxxxxxxxx
+SAPI_ADMIN_URL=xxxxxxxxxx

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "i18n-js", ">= 3.0.0.rc11"
 # Models versioning
 gem 'paper_trail', '~> 5.0'
 
+gem 'select2-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,8 @@ GEM
       wasabi (~> 3.4)
     secondbase (2.1.0)
       rails (>= 4.0)
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     sidekiq (4.2.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -354,6 +356,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   savon
   secondbase
+  select2-rails
   sidekiq
   simplecov
   spring

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap.min
+//= require select2
 //= require turbolinks
 //= require react
 //= require react_ujs

--- a/app/assets/javascripts/components/dropdown.js.coffee
+++ b/app/assets/javascripts/components/dropdown.js.coffee
@@ -1,4 +1,4 @@
-{div, input, span, a, i, button, ul, li } = React.DOM
+{div, input, span, a, i, button, ul, li, select, option } = React.DOM
 window.Dropdown = class Dropdown extends React.Component
   constructor: (props, context) ->
     super(props, context)
@@ -12,7 +12,6 @@ window.Dropdown = class Dropdown extends React.Component
       value: props.value
       form: props.form
     }
-    @processSelection = @processSelection.bind(@)
     @setBlank = @setBlank.bind(@)
 
   render: ->
@@ -28,28 +27,17 @@ window.Dropdown = class Dropdown extends React.Component
     name = if @state.form then "#{@state.form}[#{@state.name}]" else @state.name
     div(
       {}
-      button(
-        { "data-toggle": 'dropdown' }
-        span({}, (@state.value || @state.placeholder))
-        i({ className: 'fa fa-caret-down'})
-      )
-      ul(
-        { className: 'dropdown-menu' }
-        for item in @state.data
-          li({ key: item, onClick: @processSelection },
-            a({}, item)
-          )
-      )
-      input(
+      select(
         {
-          className: 'dropdown-input',
+          id: "#{@state.name}_dropdown",
+          className: 'dropdown-menu',
           name: name
-          type: 'text',
-          defaultValue: @state.value || ''
-          ref: 'textInput'
         }
+        option(
+          { defaultValue: @state.value }
+          @state.value
+        )
       )
-
     )
 
   renderCheckbox: ->
@@ -61,13 +49,17 @@ window.Dropdown = class Dropdown extends React.Component
       span({}, 'Set blank')
     )
 
-  processSelection: (e) ->
-    item = $(e.currentTarget).find('a').html()
-    @setState({value: item})
-
   setBlank: ->
     @setState({value: ' '})
 
   componentWillUpdate: (nextProps, nextState)->
     @refs.textInput.value = nextState.value
+
+  componentDidMount: ->
+    $("##{@state.name}_dropdown").select2({
+      placeholder: @state.placeholder,
+      data: @state.data.map (value) ->
+        id: value
+        text: value
+    })
 

--- a/app/assets/javascripts/components/dropdown.js.coffee
+++ b/app/assets/javascripts/components/dropdown.js.coffee
@@ -56,10 +56,17 @@ window.Dropdown = class Dropdown extends React.Component
     @refs.textInput.value = nextState.value
 
   componentDidMount: ->
-    $("##{@state.name}_dropdown").select2({
-      placeholder: @state.placeholder,
-      data: @state.data.map (value) ->
+    data = []
+    if @state.name in ['trading_partner', 'country_of_origin']
+      data = @state.data.map (value) ->
+        id: value[0]
+        text: value[1]
+    else
+      data = @state.data.map (value) ->
         id: value
         text: value
+    $("##{@state.name}_dropdown").select2({
+      placeholder: @state.placeholder,
+      data: data
     })
 

--- a/app/assets/javascripts/components/dropdown.js.coffee
+++ b/app/assets/javascripts/components/dropdown.js.coffee
@@ -12,6 +12,7 @@ window.Dropdown = class Dropdown extends React.Component
       value: props.value
       form: props.form
       apiBaseUrl: props.apiBaseUrl
+      isBlank: false
     }
     @setBlank = @setBlank.bind(@)
 
@@ -51,10 +52,7 @@ window.Dropdown = class Dropdown extends React.Component
     )
 
   setBlank: ->
-    @setState({value: ' '})
-
-  componentWillUpdate: (nextProps, nextState)->
-    @refs.textInput.value = nextState.value
+    @setState({isBlank: !@state.isBlank})
 
   componentDidMount: ->
     data = []
@@ -73,6 +71,16 @@ window.Dropdown = class Dropdown extends React.Component
       placeholder: @state.placeholder,
       data: data
     })
+
+  componentDidUpdate: ->
+    dropdown = "##{@state.name}_dropdown"
+    if @state.isBlank
+      $(dropdown).html('').select2({data: [{id: '', text: ''}]})
+    else
+      data = @state.data.map (value) ->
+        id: value
+        text: value
+      $(dropdown).html('').select2({data: data}).val(@state.value).trigger('change')
 
   select2TaxonConcept: ->
     $("#taxon_name_dropdown").select2({

--- a/app/assets/javascripts/components/dropdown.js.coffee
+++ b/app/assets/javascripts/components/dropdown.js.coffee
@@ -70,6 +70,7 @@ window.Dropdown = class Dropdown extends React.Component
     $("##{@state.name}_dropdown").select2({
       placeholder: @state.placeholder,
       data: data
+      sorter: @sortByText
     })
 
   componentDidUpdate: ->
@@ -85,7 +86,7 @@ window.Dropdown = class Dropdown extends React.Component
   select2TaxonConcept: ->
     $("#taxon_name_dropdown").select2({
       minimumInputLength: 3
-      quietMillis: 500,
+      quietMillis: 500
       ajax:
         url: "#{@state.apiBaseUrl}/api/v1/auto_complete_taxon_concepts.json"
         dataType: 'json'
@@ -107,3 +108,10 @@ window.Dropdown = class Dropdown extends React.Component
           results: formatted_taxon_concepts
           more: more
     })
+
+  sortByText: (results) ->
+    query = $('.select2-search__field').val().toUpperCase()
+    results.sort (a, b) ->
+      firstPos = a.text.toUpperCase().indexOf(query.toUpperCase())
+      secondPos = b.text.toUpperCase().indexOf(query.toUpperCase())
+      return firstPos - secondPos

--- a/app/assets/javascripts/components/dropdown.js.coffee
+++ b/app/assets/javascripts/components/dropdown.js.coffee
@@ -56,11 +56,7 @@ window.Dropdown = class Dropdown extends React.Component
 
   componentDidMount: ->
     data = []
-    if @state.name in ['trading_partner', 'country_of_origin']
-      data = @state.data.map (value) ->
-        id: value[0]
-        text: value[1]
-    else if @state.name == 'taxon_name'
+    if @state.name == 'taxon_name'
       @select2TaxonConcept()
       return
     else
@@ -70,7 +66,9 @@ window.Dropdown = class Dropdown extends React.Component
     $("##{@state.name}_dropdown").select2({
       placeholder: @state.placeholder,
       data: data
-      sorter: @sortByText
+      matcher: (params, data) =>
+        return @matchStart(params, data)
+
     })
 
   componentDidUpdate: ->
@@ -109,9 +107,8 @@ window.Dropdown = class Dropdown extends React.Component
           more: more
     })
 
-  sortByText: (results) ->
-    query = $('.select2-search__field').val().toUpperCase()
-    results.sort (a, b) ->
-      firstPos = a.text.toUpperCase().indexOf(query.toUpperCase())
-      secondPos = b.text.toUpperCase().indexOf(query.toUpperCase())
-      return firstPos - secondPos
+  matchStart: (params, data) ->
+    params.term = params.term || ''
+    if data.text.toUpperCase().indexOf(params.term.toUpperCase()) == 0
+      return data
+    return false

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,5 @@
 @import "trt_layout";
 @import "annual_report_upload";
 @import "sandbox";
+@import "select2";
+@import "select2-bootstrap";

--- a/app/assets/stylesheets/sandbox.scss
+++ b/app/assets/stylesheets/sandbox.scss
@@ -227,3 +227,7 @@ h3.sandbox-upload-summary {
 .changes-link { height: 0; }
 
 .dropdown-input { display: none; }
+
+// OVERRIDES
+
+span.select2-container { width: 100% !important; }

--- a/app/models/purpose.rb
+++ b/app/models/purpose.rb
@@ -1,0 +1,3 @@
+class Purpose < TradeCode
+  validates :code, :length => { :is => 1 }
+end

--- a/app/models/sapi/geo_entity.rb
+++ b/app/models/sapi/geo_entity.rb
@@ -1,5 +1,20 @@
 module Sapi
   class GeoEntity < Sapi::Base
     belongs_to :geo_entity_type, class_name: Sapi::GeoEntityType
+
+    scope :countries, -> {
+                           includes(:geo_entity_type).
+                           where('geo_entity_types.name' => 'COUNTRY').
+                            order(:name_en)
+                         }
+
+    def name
+      send("name_#{I18n.locale}")
+    end
+
+    def self.map_for_search
+      name = "name_#{I18n.locale}"
+      countries.pluck(:iso_code2, name)
+    end
   end
 end

--- a/app/models/sapi/geo_entity.rb
+++ b/app/models/sapi/geo_entity.rb
@@ -4,8 +4,7 @@ module Sapi
 
     scope :countries, -> {
                            includes(:geo_entity_type).
-                           where('geo_entity_types.name' => 'COUNTRY').
-                            order(:name_en)
+                           where('geo_entity_types.name' => 'COUNTRY')
                          }
 
     def name
@@ -13,8 +12,7 @@ module Sapi
     end
 
     def self.map_for_search
-      name = "name_#{I18n.locale}"
-      countries.pluck(:iso_code2, name)
+      countries.order(:iso_code2).pluck(:iso_code2)
     end
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,0 +1,3 @@
+class Source < TradeCode
+  validates :code, :length => { :is => 1 }
+end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,0 +1,3 @@
+class Term < TradeCode
+  validates :code, :length => { :is => 3 }
+end

--- a/app/models/trade_code.rb
+++ b/app/models/trade_code.rb
@@ -1,0 +1,15 @@
+class TradeCode < Sapi::Base
+  validates :code, :presence => true, :uniqueness => { :scope => :type }
+
+  def self.search(query)
+    if query.present?
+      where("UPPER(code) LIKE UPPER(:query)
+            OR UPPER(name_en) LIKE UPPER(:query)
+            OR UPPER(name_fr) LIKE UPPER(:query)
+            OR UPPER(name_es) LIKE UPPER(:query)",
+            :query => "%#{query}%")
+    else
+      scoped
+    end
+  end
+end

--- a/app/models/trade_code.rb
+++ b/app/models/trade_code.rb
@@ -12,4 +12,8 @@ class TradeCode < Sapi::Base
       scoped
     end
   end
+
+  def name
+    send("name_#{I18n.locale}")
+  end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,0 +1,3 @@
+class Unit < TradeCode
+  validates :code, :length => { :is => 3 }
+end

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -33,7 +33,7 @@
         title: 'Term',
         name: 'term_code',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: Term.pluck(:code),
         enabled: true,
         value: (@shipment && @shipment.term_code),
         form: (form && form.object_name)

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -33,7 +33,7 @@
         title: 'Term',
         name: 'term_code',
         placeholder: "Please select appendix value",
-        data: Term.pluck(:code),
+        data: Term.order(:code).pluck(:code),
         enabled: true,
         value: (@shipment && @shipment.term_code),
         form: (form && form.object_name)
@@ -58,7 +58,7 @@
         title: 'Unit',
         name: 'unit_code',
         placeholder: "Please select appendix value",
-        data: Unit.pluck(:code),
+        data: Unit.order(:code).pluck(:code),
         enabled: true,
         value: (@shipment && @shipment.unit_code),
         form: (form && form.object_name)
@@ -137,7 +137,7 @@
         title: 'Purpose Code',
         name: 'purpose_code',
         placeholder: "Please select appendix value",
-        data: Purpose.pluck(:code),
+        data: Purpose.order(:code).pluck(:code),
         enabled: true,
         value: (@shipment && @shipment.purpose_code),
         form: (form && form.object_name)
@@ -150,7 +150,7 @@
         title: 'Source code',
         name: 'source_code',
         placeholder: "Please select appendix value",
-        data: Source.pluck(:code),
+        data: Source.order(:code).pluck(:code),
         enabled: true,
         blankCheckbox: true,
         value: (@shipment && @shipment.source_code),

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -137,8 +137,8 @@
         title: 'Purpose Code',
         name: 'purpose_code',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
-        enabled: false,
+        data: Purpose.pluck(:code),
+        enabled: true,
         value: (@shipment && @shipment.purpose_code),
         form: (form && form.object_name)
       })

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -58,7 +58,7 @@
         title: 'Unit',
         name: 'unit_code',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: Unit.pluck(:code),
         enabled: true,
         value: (@shipment && @shipment.unit_code),
         form: (form && form.object_name)

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -18,10 +18,10 @@
         title: 'Taxon name',
         name: 'taxon_name',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
         enabled: true,
         value: (@shipment && @shipment.taxon_name),
-        form: (form && form.object_name)
+        form: (form && form.object_name),
+        apiBaseUrl: Rails.application.secrets.sapi_staging_path
       })
     %>
   </div>

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -150,7 +150,7 @@
         title: 'Source code',
         name: 'source_code',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: Source.pluck(:code),
         enabled: true,
         blankCheckbox: true,
         value: (@shipment && @shipment.source_code),

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -5,7 +5,7 @@
         title: 'Appendix',
         name: 'appendix',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: ['I', 'II', 'III'],
         enabled: true,
         value: (@shipment && @shipment.appendix),
         form: (form && form.object_name)

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -21,7 +21,7 @@
         enabled: true,
         value: (@shipment && @shipment.taxon_name),
         form: (form && form.object_name),
-        apiBaseUrl: Rails.application.secrets.sapi_staging_path
+        apiBaseUrl: Rails.application.secrets.sapi_path
       })
     %>
   </div>

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -41,13 +41,12 @@
     %>
   </div>
   <div class="col col-sm-3 col-md-3 col-lg-3">
-    <%= react_component("Dropdown",
+    <%= react_component("InputBox",
       {
         title: 'Quantity (Qty)',
         name: 'quantity',
-        placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
         enabled: true,
+        blankCheckbox: false,
         value: (@shipment && @shipment.quantity),
         form: (form && form.object_name)
       })

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -71,7 +71,7 @@
         title: 'Trading partner',
         name: 'trading_partner',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: Sapi::GeoEntity.map_for_search,
         enabled: true,
         value: (@shipment && @shipment.trading_partner),
         form: (form && form.object_name)
@@ -86,7 +86,7 @@
         title: 'Origin',
         name: 'country_of_origin',
         placeholder: "Please select appendix value",
-        data: ['a', 'b', 'c'],
+        data: Sapi::GeoEntity.map_for_search,
         enabled: true,
         value: (@shipment && @shipment.country_of_origin),
         form: (form && form.object_name)

--- a/app/views/shipments/_form.html.erb
+++ b/app/views/shipments/_form.html.erb
@@ -173,5 +173,5 @@
 
 <div class="buttons align-right">
   <%= link_to t('cancel'), '', class: "button btn-scnd" %>
-  <%= submit_tag t('update_selection'), class: "button" %>
+  <%= submit_tag t('update'), class: "button" %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
   selected_error: "Selected error"
   edit_all_errors: "Edit all errors"
   cancel: 'Cancel'
+  update: 'Update'
   update_selection: 'Update selection'
   back_to_epix: 'Back to EPIX'
   back_to_speciesplus: 'Back to Species+'


### PR DESCRIPTION
This is about [completing the shipments edit form](https://www.pivotaltracker.com/story/show/135324665).
The dropdowns have been populated moving code from SAPI regarding the models, but also using the SAPI api regarding autocompletion of the taxon name.
To achieve this, select2 has been used.

Still regarding the taxon name, at the moment I'm not showing the name status along with the taxon name, but it's indeed possibile by, for example, uncommenting the line ` #visibility: 'trade_internal' #includes status` in the ajax call.

Originally, by Michel's design, the quantity field was a dropdown, but it seems to me that this should have been a normal text input, so I've also changed this.