### PR TITLE
Null in cites report summary

### DIFF
--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -84,7 +84,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
     upload = @state.annualReportUpload
     upload_type = ''
     if upload.is_from_web_service
-      upload_type = ' via web service upload'
+      upload_type = ' (via web service upload)'
     else
       upload_type = " via CSV upload (#{upload.file_name})"
     upload.trading_country + ' (' + upload.point_of_view + '), ' +

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -82,10 +82,14 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
 
   summary: ->
     upload = @state.annualReportUpload
+    upload_type = ''
+    if upload.is_from_web_service
+      upload_type = ' via web service upload'
+    else
+      upload_type = " via CSV upload (#{upload.file_name})"
     upload.trading_country + ' (' + upload.point_of_view + '), ' +
       upload.number_of_rows + " #{I18n.t('shipments')} " + " #{I18n.t('uploaded_on')} " +
-      upload.created_at + " #{I18n.t('by')} " + upload.created_by + ' (' +
-      upload.file_name + ')'
+      upload.created_at + " #{I18n.t('by')} " + upload.created_by + upload_type
 
   displaySubmissions: ->
     i(

--- a/app/serializers/annual_report_upload_serializer.rb
+++ b/app/serializers/annual_report_upload_serializer.rb
@@ -2,7 +2,8 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
   attributes :id, :trading_country_id, :point_of_view, :number_of_rows,
   :file_name, :created_at, :updated_at, :created_by, :updated_by,
   :submitted_at, :submitted_by,  :trading_country,
-  :number_of_records_submitted, :has_validation_report
+  :number_of_records_submitted, :has_validation_report,
+  :is_from_web_service
 
   def file_name
     object.csv_source_file.try(:path) && File.basename(object.csv_source_file.path)


### PR DESCRIPTION
[Get rid of (null) in cites report summary](https://www.pivotaltracker.com/story/show/136102853).
It just uses the `is_from_web_service` flag to display the correct text.