### PR TITLE
Download changelog and validation report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ gem 'select2-rails'
 # Connect to S3 bucket
 gem 'aws-sdk', '~> 2'
 
+gem 'rubyzip', '>= 1.0.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubyzip (1.2.0)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -368,6 +369,7 @@ DEPENDENCIES
   rails-controller-testing
   react-rails
   rspec-rails
+  rubyzip (>= 1.0.0)
   sass-rails (~> 5.0)
   savon
   secondbase

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -7,6 +7,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       submitted: !!props.annualReportUpload.submitted_at
       sandboxEnabled: !!props.sandboxEnabled
       adminUrl: props.adminUrl
+      userType: props.userType
     }
     @updateModal = @updateModal.bind(@, @summary())
 
@@ -110,3 +111,10 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
         @state.annualReportUpload.submitted_at
       )
     )
+
+  getSubmitter: ->
+    submitted_by_type = @state.annualReportUpload.submitted_by_type
+    if @state.userType == 'sapi' || (@state.userType == submitted_by_type)
+      @state.annualReportUpload.submitted_by
+    else
+      'WCMC'

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -24,6 +24,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
     else
       download_button.addClass('disabled')
     if @state.submitted
+      download_button.removeClass('disabled')
       modal_content.addClass('smaller')
       text = I18n.t('submitted_at_info_box') + " " + @getSubmitter()
       text = text + I18n.t('on') + " #{@state.annualReportUpload.submitted_at}. "

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -26,7 +26,8 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
     if @state.submitted
       modal_content.addClass('smaller')
       text = I18n.t('submitted_at_info_box') + " " + @getSubmitter()
-      text = text + I18n.t('the') + " #{@state.annualReportUpload.submitted_at}"
+      text = text + I18n.t('on') + " #{@state.annualReportUpload.submitted_at}. "
+      text = text + I18n.t('download_info_box')
       info_text.html(text)
     else
       modal_content.removeClass('smaller')

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -25,7 +25,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       download_button.addClass('disabled')
     if @state.submitted
       modal_content.addClass('smaller')
-      text = I18n.t('submitted_at_info_box') + " #{@state.annualReportUpload.submitted_by} "
+      text = I18n.t('submitted_at_info_box') + " " + @getSubmitter()
       text = text + I18n.t('the') + " #{@state.annualReportUpload.submitted_at}"
       info_text.html(text)
     else
@@ -103,7 +103,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       " #{I18n.t('records_submitted_by')} "
       span(
         {className: 'bold'}
-        @state.annualReportUpload.submitted_by
+        @getSubmitter()
       )
       " #{I18n.t('the')} "
       span(

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -25,13 +25,11 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
       download_button.addClass('disabled')
     if @state.submitted
       download_button.removeClass('disabled')
-      modal_content.addClass('smaller')
       text = I18n.t('submitted_at_info_box') + " " + @getSubmitter()
       text = text + I18n.t('on') + " #{@state.annualReportUpload.submitted_at}. "
       text = text + I18n.t('download_info_box')
       info_text.html(text)
     else
-      modal_content.removeClass('smaller')
       text = I18n.t('change_sandbox_settings')
       text = text + "<a href='#{@state.adminUrl}' class='bold'>#{I18n.t('your_admin_page')}</a>"
       info_text.html(text)

--- a/app/assets/javascripts/components/annual_report_upload.js.coffee
+++ b/app/assets/javascripts/components/annual_report_upload.js.coffee
@@ -26,7 +26,7 @@ window.AnnualReportUpload = class AnnualReportUpload extends React.Component
     if @state.submitted
       download_button.removeClass('disabled')
       text = I18n.t('submitted_at_info_box') + " " + @getSubmitter()
-      text = text + I18n.t('on') + " #{@state.annualReportUpload.submitted_at}. "
+      text = text + " " + I18n.t('on') + " #{@state.annualReportUpload.submitted_at}. "
       text = text + I18n.t('download_info_box')
       info_text.html(text)
     else

--- a/app/assets/javascripts/components/annual_report_uploads.js.coffee
+++ b/app/assets/javascripts/components/annual_report_uploads.js.coffee
@@ -8,6 +8,7 @@ window.AnnualReportUploads = class AnnualReportUploads extends React.Component
       page: props.page,
       sandboxEnabled: props.sandboxEnabled
       adminUrl: props.adminUrl
+      userType: props.userType
     }
 
   render: ->
@@ -33,6 +34,7 @@ window.AnnualReportUploads = class AnnualReportUploads extends React.Component
             annualReportUpload: annualReportUpload,
             sandboxEnabled: @state.sandboxEnabled
             adminUrl: @state.adminUrl
+            userType: @state.userType
           }
         )
       )

--- a/app/assets/javascripts/components/annual_report_uploads_container.js.coffee
+++ b/app/assets/javascripts/components/annual_report_uploads_container.js.coffee
@@ -10,6 +10,8 @@ window.AnnualReportUploadsContainer = class AnnualReportUploadsContainer extends
       page: 1,
       sandboxEnabled: props.sandboxEnabled
       adminUrl: props.adminUrl
+      userType: props.userType
+
     }
     @incrementPage = @changePage.bind(@, 1)
     @decrementPage = @changePage.bind(@, -1)
@@ -29,6 +31,7 @@ window.AnnualReportUploadsContainer = class AnnualReportUploadsContainer extends
           page: @state.page,
           sandboxEnabled: @state.sandboxEnabled
           adminUrl: @state.adminUrl
+          userType: @state.userType
         }
       )
       @renderPaginator() if @state.totalPages > 1

--- a/app/assets/javascripts/translations/en.js
+++ b/app/assets/javascripts/translations/en.js
@@ -21,8 +21,10 @@ I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}),
     "edit": "Edit",
     "edit_all_errors": "Edit all affected errors",
     "close": "Close",
-    "submitted_at_info_box": "This report has been submitted by",
+    "submitted_at_info_box": "This CITES report has been submitted by",
     "change_sandbox_settings": "If you would like to correct these existing errors by using the app sandbox please update the relevant settings on ",
-    "your_admin_page": "your admin account page."
+    "your_admin_page": "your admin account page.",
+    "on": "on",
+    "download_info_box": "You can download the validation report and log of changelog detailing any changes made within the online correction tool"
   }
 )

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -80,6 +80,10 @@ class AnnualReportUploadsController < ApplicationController
 
   def download_error_report
     aru = Trade::AnnualReportUpload.find(params[:id])
+    unless aru.is_submitted?
+      render json: { error: t('download_report_disabled') }
+      return
+    end
     validation_report_csv_file = ValidationReportCsvGenerator.call(aru)
 
     changelog = aru.get_changelog("changelog_#{aru.id}-")

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -80,7 +80,7 @@ class AnnualReportUploadsController < ApplicationController
 
   def download_error_report
     aru = Trade::AnnualReportUpload.find(params[:id])
-    unless aru.is_submitted?
+    if !aru.is_submitted? && aru.validation_report.empty?
       render json: { error: t('download_report_disabled') }
       return
     end

--- a/app/controllers/annual_report_uploads_controller.rb
+++ b/app/controllers/annual_report_uploads_controller.rb
@@ -1,3 +1,4 @@
+require 'zip'
 class AnnualReportUploadsController < ApplicationController
   before_action :authorise_edit, only: [:destroy]
   respond_to :json
@@ -80,9 +81,18 @@ class AnnualReportUploadsController < ApplicationController
   def download_error_report
     aru = Trade::AnnualReportUpload.find(params[:id])
     validation_report_csv_file = ValidationReportCsvGenerator.call(aru)
-    data = File.read(validation_report_csv_file)
 
-    send_data data, type: 'text/csv', filename: "validation_report_#{aru.id}.csv"
+    changelog = aru.get_changelog("changelog_#{aru.id}-")
+    zipfile = "#{Rails.root.join('tmp')}/report_#{aru.id}.zip"
+    Zip::File.open(zipfile, Zip::File::CREATE) do |zipfile|
+      zipfile.add('changelog.csv', changelog.path)
+      zipfile.add('validation_report.csv', validation_report_csv_file.path)
+    end
+
+    data = File.read(zipfile)
+    changelog.delete
+    File.delete(zipfile)
+    send_data data, type: 'application/zip', filename: "report_#{aru.id}.zip"
   end
 
 end

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -151,6 +151,20 @@ class Trade::AnnualReportUpload < Sapi::Base
     end
   end
 
+  def get_changelog(filename)
+    changelog = Tempfile.new([filename, ".csv"], Rails.root.join('tmp'))
+    begin
+      s3 = Aws::S3::Client.new
+      bucket = Rails.application.secrets.aws['bucket_name']
+      key = "#{Rails.env}/trade/annual_report_upload/#{self.id}/changelog.csv"
+      s3.get_object({bucket: bucket, key: key}, target: changelog.path)
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn "Something went wrong while uploading #{self.id} to S3"
+      Appsignal.add_exception(e) if defined? Appsignal
+    end
+    changelog
+  end
+
   private
 
   # Expects a relation object

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -28,8 +28,14 @@ class Trade::AnnualReportUpload < Sapi::Base
       where("epix_created_by_id IS NULL")
     end
   }
-  scope :submitted, -> { where("submitted_at IS NOT NULL OR epix_submitted_at IS NOT NULL") }
-  scope :in_progress, -> { where("submitted_at IS NULL AND epix_submitted_at IS NULL") }
+  scope :submitted, -> {
+    where("submitted_at IS NOT NULL OR epix_submitted_at IS NOT NULL").
+    order(created_at: :desc, epix_created_at: :desc)
+  }
+  scope :in_progress, -> {
+    where("submitted_at IS NULL AND epix_submitted_at IS NULL").
+    order(created_at: :desc, epix_created_at: :desc)
+  }
 
   validates :trading_country_id, presence: true
   validates :point_of_view, inclusion: { in: ['E', 'I'] }

--- a/app/models/trade/annual_report_upload.rb
+++ b/app/models/trade/annual_report_upload.rb
@@ -72,7 +72,7 @@ class Trade::AnnualReportUpload < Sapi::Base
   end
 
   def is_submitted?
-    submitted_at.present?
+    submitted_at.present? || epix_submitted_at.present?
   end
 
   def reported_by_exporter?

--- a/app/serializers/annual_report_upload_serializer.rb
+++ b/app/serializers/annual_report_upload_serializer.rb
@@ -65,6 +65,16 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
     end
   end
 
+  def submitted_by_type
+    if object.epix_submitter
+      'epix'
+    elsif object.sapi_submitter
+      'sapi'
+    else
+      ''
+    end
+  end
+
   def trading_country
     object.trading_country && object.trading_country.name_en
   end
@@ -74,4 +84,3 @@ class AnnualReportUploadSerializer < ActiveModel::Serializer
   end
 
 end
-

--- a/app/serializers/show_annual_report_upload_serializer.rb
+++ b/app/serializers/show_annual_report_upload_serializer.rb
@@ -65,7 +65,7 @@ class ShowAnnualReportUploadSerializer < ActiveModel::Serializer
     _created_by = (object.epix_creator || object.sapi_creator).name
     object.trading_country.name_en + ' (' + object.point_of_view + '), ' +
       object.number_of_rows.to_s + ' shipments' + ' uploaded on ' + _created_at +
-      ' by ' + _created_by + ' ('  + (file_name || '') + ')'
+      ' by ' + _created_by + ' ('  + (object.file_name || '') + ')'
   end
 
   def has_validation_report

--- a/app/views/annual_report_uploads/_download_modal.html.erb
+++ b/app/views/annual_report_uploads/_download_modal.html.erb
@@ -5,12 +5,12 @@
       <h2 class="modal-title"><%= t('download_report') %></h2>
     </div>
     <div class="modal-body">
-      <p class="download-info"><%= t('download_info') %></p>
-      <p class="file-to-download"></p>
       <div class="change-sandbox-settings info-box">
         <i class="fa fa-info-circle"></i>
         <span class="info-text"><%= t('change_sandbox_settings').html_safe %></span>
       </div>
+      <p class="download-info"><%= t('download_info') %></p>
+      <p class="file-to-download"></p>
       <div class="buttons right">
         <%=
           button_tag('Cancel',

--- a/app/views/annual_report_uploads/index.html.erb
+++ b/app/views/annual_report_uploads/index.html.erb
@@ -45,7 +45,8 @@
           {
             pageName: 'submitted_uploads',
             totalPages: @submitted_pages,
-            sandboxEnabled: @sandbox_enabled
+            sandboxEnabled: @sandbox_enabled,
+            userType: current_epix_user ? 'epix' : current_sapi_user ? 'sapi' : ''
           }
       %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,3 +58,4 @@ en:
   shipment_updated: 'Shipment successfully updated.'
   shipment_not_updated: 'An error occurred while updating shipment.'
   aru_changelog_generation_scheduled: 'Generation of changelog scheduled. An email notification will be delivered.'
+  download_report_disabled: "You can't download a report that has not been submitted yet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,4 +58,4 @@ en:
   shipment_updated: 'Shipment successfully updated.'
   shipment_not_updated: 'An error occurred while updating shipment.'
   aru_changelog_generation_scheduled: 'Generation of changelog scheduled. An email notification will be delivered.'
-  download_report_disabled: "You can't download a report that has not been submitted yet."
+  download_report_disabled: "You can't download a report that has not been submitted or does not have a validation report yet."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
   upload_file: 'Upload a file (CSV format)'
   choose_file: 'Please choose a file'
   download_report: 'Download report'
-  download_info: 'You are about to download the following report on existing errors:'
+  download_info: 'You are about to download a report on the following submission:'
   download_report_on_errors: "Download report on existing errors"
   submit_shipments: "Submit shipments"
   back_to_shipments: "Back to shipments' list"

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -315,8 +315,9 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
         get 'download_error_report', params: {
           id: @aru.id
         }
-        expect(response.content_type).to eq('text/csv')
-        expect(response.body).to include("II")
+        expect(response.content_type).to eq('application/zip')
+        expect(response.body).to include("validation_report.csv")
+        expect(response.body).to include("changelog.csv")
       end
     end
   end

--- a/spec/controllers/annual_report_uploads_controller_spec.rb
+++ b/spec/controllers/annual_report_uploads_controller_spec.rb
@@ -306,6 +306,9 @@ RSpec.describe AnnualReportUploadsController, type: :controller do
         allow_any_instance_of(Trade::Sandbox).to(
           receive(:copy_from_sandbox_to_shipments).with(@epix_user).and_return(true)
         )
+        allow_any_instance_of(Aws::S3::Client).to(
+          receive(:get_object).and_return(true)
+        )
         CitesReportValidator.call(@aru.id, @epix_user)
       end
       it "should download validation report" do


### PR DESCRIPTION
This is about downloading the validation report and the changelog in one go for submitted arus, using the download button in the modal window.
The changelog is retrieved form S3 and then it will be zipped along with the validation report.

Also here some bugfixing regarding a serializer and the `is_submitted?` method, which will now also consider the `epix_submitted_at` field.