### PR TITLE
Add spinner while loading

### DIFF
--- a/app/assets/javascripts/components/annual_report_uploads.js.coffee
+++ b/app/assets/javascripts/components/annual_report_uploads.js.coffee
@@ -48,6 +48,7 @@ window.AnnualReportUploads = class AnnualReportUploads extends React.Component
       success: (response) =>
         data = response.annual_report_uploads
         @setState({data: data[props.pageName]})
+        $('.fa-spinner').hide()
       error: (response) ->
         console.log("Something went wrong")
     })

--- a/app/assets/stylesheets/annual_report_upload.scss
+++ b/app/assets/stylesheets/annual_report_upload.scss
@@ -163,3 +163,10 @@ input.real-file-input {
     top: -2px;
   }
 }
+
+.fa-spinner {
+  color: $main-blue;
+  position: relative;
+  left: 50%;
+  padding: 30px 0;
+}

--- a/app/views/annual_report_uploads/index.html.erb
+++ b/app/views/annual_report_uploads/index.html.erb
@@ -30,6 +30,7 @@
   <% end %>
   <div class="uploads-lists col col-sm-9 col-md-9 col-lg-9">
     <h4 class="bold"><%= t('uploads_in_progress') %></h4>
+    <i class="fa fa-spinner fa-pulse fa-3x"></i>
       <%=
         react_component 'AnnualReportUploadsContainer',
           {
@@ -40,6 +41,7 @@
           }
       %>
     <h4 class="bold"><%= t('past_uploads') %></h4>
+    <i class="fa fa-spinner fa-pulse fa-3x"></i>
       <%=
         react_component 'AnnualReportUploadsContainer',
           {


### PR DESCRIPTION
This PR adds a spinner to the index page of the annual report uploads to notify that data is loading.
Once data is loaded, this will be hidden.