### PR TITLE
Fix back to shipments link

### DIFF
--- a/app/assets/stylesheets/sandbox.scss
+++ b/app/assets/stylesheets/sandbox.scss
@@ -130,7 +130,7 @@ h3.sandbox-upload-summary {
   &:hover { color: $main-green; }
 }
 
-.back-to-shipments {
+.back-link {
   margin: 20px 0;
 }
 

--- a/app/views/annual_report_uploads/changes_history.html.erb
+++ b/app/views/annual_report_uploads/changes_history.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/back_to_shipments" %>
+<%= render "shared/back_link" %>
 <h3 class="sandbox-upload-summary no-border">
   <%= @annual_report_upload.summary %>
 </h3>

--- a/app/views/annual_report_uploads/changes_history.html.erb
+++ b/app/views/annual_report_uploads/changes_history.html.erb
@@ -1,4 +1,10 @@
-<%= render "shared/back_link" %>
+<%=
+  render partial: "shared/back_link",
+    locals: {
+      text: t('back_to_report') ,
+      link: annual_report_upload_path(@annual_report_upload)
+    }
+%>
 <h3 class="sandbox-upload-summary no-border">
   <%= @annual_report_upload.summary %>
 </h3>

--- a/app/views/shared/_back_link.html.erb
+++ b/app/views/shared/_back_link.html.erb
@@ -1,4 +1,4 @@
-<div class='back-to-shipments'>
+<div class='back-link'>
   <i class='fa fa-long-arrow-left green'></i>
   <%= link_to t('back_to_shipments'), '', class: 'green-link-underlined' %>
 </div>

--- a/app/views/shared/_back_link.html.erb
+++ b/app/views/shared/_back_link.html.erb
@@ -1,5 +1,5 @@
 <div class='back-link'>
   <i class='fa fa-long-arrow-left green'></i>
-  <%= link_to t('back_to_shipments'), '', class: 'green-link-underlined' %>
+  <%= link_to text, link, class: 'green-link-underlined' %>
 </div>
 

--- a/app/views/shipments/edit.html.erb
+++ b/app/views/shipments/edit.html.erb
@@ -1,4 +1,10 @@
-<%= render "shared/back_link" %>
+<%=
+  render partial: "shared/back_link",
+    locals: {
+      text: t('back_to_report') ,
+      link: annual_report_upload_path(@annual_report_upload)
+    }
+%>
 <h1 class="bold"><%= t('edit') %></h1>
 <div class="edit-container">
   <%=

--- a/app/views/shipments/edit.html.erb
+++ b/app/views/shipments/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/back_to_shipments" %>
+<%= render "shared/back_link" %>
 <h1 class="bold"><%= t('edit') %></h1>
 <div class="edit-container">
   <%=

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -1,4 +1,11 @@
-<%= render "shared/back_link" %>
+<%=
+  render partial: "shared/back_link",
+    locals: {
+      text: t('back_to_report') ,
+      link: annual_report_upload_path(@annual_report_upload)
+    }
+%>
+
 <div class='top-info-box'>
   <span><%= t('selected_error') %>:</span><span class='bold'> <%= @error %></span>
 </div>

--- a/app/views/shipments/index.html.erb
+++ b/app/views/shipments/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/back_to_shipments" %>
+<%= render "shared/back_link" %>
 <div class='top-info-box'>
   <span><%= t('selected_error') %>:</span><span class='bold'> <%= @error %></span>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,3 +59,4 @@ en:
   shipment_not_updated: 'An error occurred while updating shipment.'
   aru_changelog_generation_scheduled: 'Generation of changelog scheduled. An email notification will be delivered.'
   download_report_disabled: "You can't download a report that has not been submitted or does not have a validation report yet."
+  back_to_report: "Back to report"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
   post 'annual_report_uploads/:id/submit', to: 'annual_report_uploads#submit', as: 'submit'
   resources :annual_report_uploads, only: [:index, :show, :destroy] do
     resources :shipments, only: [:index, :edit, :update, :destroy]
-    get 'validation_errors/:validation_error_id/shipments', to: 'shipments#index', as: 'shipment_with_errors'
+    get 'validation_errors/:validation_error_id/shipments', to: 'shipments#index', as: 'shipments_with_errors'
   end
 
   wash_out "api/v1/cites_reporting"


### PR DESCRIPTION
This fixes the back to shipments link to redirect to the aru page.
I thought this would have been more consistent, both renaming it to `Back to report` and also then redirecting to the index page of the selected annual report upload.